### PR TITLE
Fix/variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ABAC allows us to define access/deny policies based around any conceivable attri
  - **The resource**: The entity the action is related to or being performed on.
  - **The environment**: Any environmental attributes eg. Time, IP address, location.
 
-With policies defined using rules with access to this information we can then enforce our Policies in any part of a distrubuted system.
+With policies defined using rules with access to this information we can then enforce our Policies in any part of a distributed system.
 
 You can find out more about the concepts involved here: [ABAC Overview]({{ link('ABAC Overview') }}).
 

--- a/core/src/commonMain/kotlin/codes.laurence.warden/decision/DecisionPointLocal.kt
+++ b/core/src/commonMain/kotlin/codes.laurence.warden/decision/DecisionPointLocal.kt
@@ -26,13 +26,13 @@ class DecisionPointLocal(
     constructor(
         allow: List<Policy>,
         deny: List<Policy> = emptyList(),
-        informationProvider: InformationPoint = InformationPointPassThrough()
+        informationPoint: InformationPoint = InformationPointPassThrough()
     ) : this(
         policySource = PolicySourceInMemory(
             allow,
             deny
         ),
-        informationPoint = informationProvider
+        informationPoint = informationPoint
     )
 
     override suspend fun checkAuthorized(request: AccessRequest): AccessResponse {

--- a/core/src/commonTest/kotlin/codes/laurence/warden/decision/InMemoryDecisionPointTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/decision/InMemoryDecisionPointTest.kt
@@ -19,7 +19,7 @@ val accessRequest = AccessRequest().copy(
 val enrichedRequest = AccessRequest().copy(
     action = mapOf("foo" to "enriched")
 )
-val informationProviderMock = mockk<InformationPoint> {
+val informationPointMock = mockk<InformationPoint> {
     coEvery { enrich(accessRequest) } returns enrichedRequest
 }
 
@@ -45,13 +45,13 @@ class InMemoryDecisionPointTest {
         val testObj = DecisionPointLocal(
             allow = listOf(accessPolicyMock),
             deny = listOf(denyPolicyMock),
-            informationProvider = informationProviderMock
+            informationPoint = informationPointMock
         )
 
         testObj.checkAuthorized(accessRequest)
 
         coVerifySequence {
-            informationProviderMock.enrich(accessRequest)
+            informationPointMock.enrich(accessRequest)
             accessPolicyMock.checkAuthorized(enrichedRequest)
             denyPolicyMock.checkAuthorized(enrichedRequest)
         }

--- a/docs/src/orchid/resources/homepage.md
+++ b/docs/src/orchid/resources/homepage.md
@@ -18,7 +18,7 @@ ABAC allows us to define access/deny policies based around any conceivable attri
 - **The environment**: Any environmental attributes eg. Time, IP address, location.
 
 With policies defined using rules with access to this information we can then enforce our Policies in any part of a
-distrubuted system.
+distributed system.
 
 You can find out more about the concepts involved here: [ABAC Overview]({{ link('ABAC Overview') }}).
 


### PR DESCRIPTION
Had an `InformationProvider` lying around from before a refactor to be in line with ABAC InformationPoint