### PR TITLE
Maven Central publishing config

### DIFF
--- a/buildSrc/src/main/kotlin/buildsrc/config/publishing.kt
+++ b/buildSrc/src/main/kotlin/buildsrc/config/publishing.kt
@@ -1,6 +1,14 @@
 package buildsrc.config
 
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.findByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 fun MavenPublication.createWardenPom(
     pomDescription: String = "https://github.com/lgwillmore/warden",
@@ -34,4 +42,36 @@ fun MavenPublication.createWardenPom(
     issueManagement {
         url.set("https://github.com/lgwillmore/warden/issues")
     }
+}
+
+/**
+ * Fetches credentials from `gradle.properties`, environment variables, or command line args.
+ *
+ * See https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:handling_credentials
+ */
+// https://github.com/gradle/gradle/issues/20925
+fun ProviderFactory.credentialsAction(
+    repositoryName: String
+): Provider<Action<PasswordCredentials>> = zip(
+    gradleProperty("${repositoryName}Username"),
+    gradleProperty("${repositoryName}Password"),
+) { user, pass ->
+    Action<PasswordCredentials> {
+        username = user
+        password = pass
+    }
+}
+
+/**
+ * Check if a Kotlin Mutliplatform project also has Java enabled.
+ *
+ * Logic from [KotlinJvmTarget.withJava]
+ */
+fun Project.isKotlinMultiplatformJavaEnabled(): Boolean {
+    val multiplatformExtension: KotlinMultiplatformExtension? =
+        extensions.findByType(KotlinMultiplatformExtension::class)
+
+    return multiplatformExtension?.targets
+        ?.any { it is KotlinJvmTarget && it.withJavaEnabled }
+        ?: false
 }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/sonatype-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/sonatype-publish.gradle.kts
@@ -1,0 +1,143 @@
+package buildsrc.convention
+
+import buildsrc.config.createWardenPom
+import buildsrc.config.credentialsAction
+import buildsrc.config.isKotlinMultiplatformJavaEnabled
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMultiplatformPlugin
+
+plugins {
+    `maven-publish`
+    signing
+}
+
+description = "Configuration for publishing to Sonatype Maven Central"
+
+// in $GRADLE_USER_HOME/gradle.properties, set
+// sonatypeRepositoryUsername=...
+// sonatypeRepositoryPassword=...
+// Or set environment variables
+// ORG_GRADLE_PROJECT_sonatypeRepositoryUsername=...
+// ORG_GRADLE_PROJECT_sonatypeRepositoryPassword=...
+val sonatypeRepositoryCredentials: Provider<Action<PasswordCredentials>> =
+    providers.credentialsAction("sonatypeRepository")
+
+val sonatypeRepositoryReleaseUrl: Provider<String> = provider {
+    if (version.toString().endsWith("SNAPSHOT")) {
+        "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+    } else {
+        "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+    }
+}
+
+val signingKeyId: Provider<String> =
+    providers.gradleProperty("signing.keyId")
+val signingKey: Provider<String> =
+    providers.gradleProperty("signing.key")
+val signingPassword: Provider<String> =
+    providers.gradleProperty("signing.password")
+val signingSecretKeyRingFile: Provider<String> =
+    providers.gradleProperty("signing.secretKeyRingFile")
+
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    // Gradle warns about some signing tasks using publishing task outputs without explicit
+    // dependencies. I'm not going to go through them all and fix them, so here's a quick fix.
+    dependsOn(tasks.withType<Sign>())
+    mustRunAfter(tasks.withType<Sign>())
+
+    doLast {
+        logger.lifecycle("[${this.name}] ${project.group}:${project.name}:${project.version}")
+    }
+}
+
+afterEvaluate {
+    // Register signatures afterEvaluate, otherwise the signing plugin creates the signing tasks
+    // too early, before all the publications are added.
+
+    if (sonatypeRepositoryCredentials.isPresent()) {
+        // Use .all { }, not .configureEach { }, otherwise the signing plugin doesn't create the
+        // signing tasks soon enough.
+        publishing.publications.withType<MavenPublication>().all {
+            signing.sign(this)
+            logger.lifecycle("configuring signature for publication ${this.name}")
+        }
+    }
+}
+
+signing {
+    if (sonatypeRepositoryCredentials.isPresent()) {
+        if (signingKeyId.isPresent() && signingKey.isPresent() && signingPassword.isPresent()) {
+            useInMemoryPgpKeys(signingKeyId.get(), signingKey.get(), signingPassword.get())
+        } else {
+            useGpgCmd()
+        }
+    }
+}
+
+
+publishing {
+    if (sonatypeRepositoryCredentials.isPresent()) {
+        repositories {
+            maven(sonatypeRepositoryReleaseUrl) {
+                name = "sonatype"
+                credentials(sonatypeRepositoryCredentials.get())
+            }
+            // publish to local dir, for testing
+            maven(rootProject.layout.buildDirectory.dir("maven-internal")) {
+                name = "LocalProjectDir"
+            }
+        }
+        publications.withType<MavenPublication>().configureEach {
+            createWardenPom()
+        }
+    }
+}
+
+plugins.withType<KotlinMultiplatformPlugin>().configureEach {
+    publishing.publications.withType<MavenPublication>().configureEach {
+        // if required, do specific Kotlin Multiplatform configuration
+        // Kotlin Multiplatform automatically registers publications
+    }
+}
+
+plugins.withType<JavaPlugin>().configureEach {
+    afterEvaluate {
+        // Here we only want to apply config to non-KMP projects, so check to only do that if the
+        // KMP plugin isn't also enabled (it automatically applies the Java plugin).
+        if (!isKotlinMultiplatformJavaEnabled()) {
+            publishing.publications.create<MavenPublication>("mavenJava") {
+                from(components["java"])
+//                artifact(tasks["sourcesJar"])
+            }
+        }
+    }
+}
+
+fun Project.javadocStubTask(): Jar {
+
+    // use creating, not registering, because the signing plugin sucks
+    val javadocJarStub by tasks.creating(Jar::class) {
+        group = JavaBasePlugin.DOCUMENTATION_GROUP
+        description = "Stub javadoc.jar artifact (required by Maven Central)"
+        archiveClassifier.set("javadoc")
+    }
+
+    tasks.withType<AbstractPublishToMaven>().all {
+        dependsOn(javadocJarStub)
+    }
+
+    publishing {
+        publications.withType<MavenPublication>().configureEach {
+            artifact(javadocJarStub)
+        }
+    }
+
+    if (sonatypeRepositoryCredentials.isPresent()) {
+        val signingTasks = signing.sign(javadocJarStub)
+        tasks.withType<AbstractPublishToMaven>().all {
+            signingTasks.forEach { dependsOn(it) }
+        }
+    }
+
+    return javadocJarStub
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,8 +1,6 @@
-import buildsrc.config.createWardenPom
-
 plugins {
     buildsrc.convention.`kotlin-multiplatform`
-    buildsrc.convention.`artifactory-publish`
+    buildsrc.convention.`sonatype-publish`
 }
 
 val assertKVersion: String by project
@@ -10,6 +8,9 @@ val mockkVersion: String by project
 val kotlinVersion: String by project
 
 kotlin {
+
+    jvm()
+
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -38,28 +39,4 @@ kotlin {
             }
         }
     }
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("coreJVM") {
-            artifact(tasks.jvmJar)
-            artifact(tasks.jvmSourcesJar)
-
-            createWardenPom()
-        }
-    }
-}
-
-artifactory {
-    publish {
-        defaults {
-            publications("coreJVM")
-        }
-    }
-}
-
-tasks.artifactoryPublish.configure {
-    dependsOn(tasks.build)
-//    dependsOn(tasks.publishJvmPublicationToMavenLocal)
 }

--- a/ktor/build.gradle.kts
+++ b/ktor/build.gradle.kts
@@ -1,8 +1,6 @@
-import buildsrc.config.createWardenPom
-
 plugins {
     buildsrc.convention.`kotlin-jvm`
-    buildsrc.convention.`artifactory-publish`
+    buildsrc.convention.`sonatype-publish`
 }
 
 val ktorVersion: String by project
@@ -22,32 +20,4 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:$assertKVersion")
     testImplementation(kotlin("test"))
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("ktor") {
-            artifact(tasks.jar)
-            artifact(tasks.sourcesJar)
-            artifact(tasks.javadocJar)
-
-            createWardenPom()
-        }
-    }
-}
-
-artifactory {
-    publish {
-        defaults {
-            publications("ktor")
-        }
-    }
-}
-
-tasks.build.configure {
-    dependsOn(tasks.kotlinSourcesJar)
-}
-
-tasks.artifactoryPublish.configure {
-    dependsOn(tasks.build)
 }


### PR DESCRIPTION
### Setup

In `$GRADLE_USER_HOME/gradle.properties` set the following.

```properties
# https://central.sonatype.org/publish/publish-gradle/#credentials
sonatypeRepositoryUsername=<...username...>
sonatypeRepositoryPassword=<...password...>

signing.keyId=<...key....>
signing.password=<...password...>
signing.secretKeyRingFile=<...>/.gnupg/adamko-dev.private.pgp
signing.key=<...really really long signature...>

signing.gnupg.keyName=<...>
signing.gnupg.executable=<...>/gpg/current/bin/gpg.exe
signing.gnupg.useLegacyGpg=true # I can't remember why I set this
```

In GitHub you can set these secrets using environment variables prefixed with `ORG_GRADLE_PROJECT_`, e.g. `ORG_GRADLE_PROJECT_sonatypeRepositoryUsername` (I'm not sure how the dots are handled...)

### Quick test

I set up publishing to a local directory for quick testing.

Test by running `./gradlew publishAllPublicationsToLocalProjectDirRepository` and checking `./build/maven-internal`

It should look something like this.

![image](https://user-images.githubusercontent.com/897017/178306201-e2ea02dd-7576-4997-83d1-3c8f710c9c83.png)

### Requirements

It's also *very* important to Sonatype that each artifact directory has 

1. A jar, e.g. `warden-core-0.1.0.jar`
2. A Javadoc jar, e.g. `warden-ktor-0.1.0.jar`
3. Every file has an `.asc` signature. (Checksum files like `.md5`. `.sha1` are excluded from this, but Gradle generates them anyway). 

### Todo

- [x] @lgwillmore Can you please check that the POMs for each artifact are okay?
- [x] @lgwillmore Enable squashed merge please :)
- [x] Javadoc isn't generated for the KMP projects - I'll try and fix this.
- [ ] In my own projects I've found that generating the `.asc` signatures requires running `gradle :publish` *twice* - hopefully we can improve that
- [ ] Set up GitHub action for publishing - maybe do this in a separate ticket?
- [ ] remove `artifactory-publishing.gradle.kts`?
