### PR TITLE
Docs tidying: formatting, and minor spelling/grammar adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ABAC allows us to define access/deny policies based around any conceivable attri
 With policies defined using rules with access to this information we can then enforce our Policies in any part of a
 distributed system.
 
-You can find out more about the concepts involved here: [ABAC Overview]({{ link('ABAC Overview') }}).
+You can find out more about the concepts involved here: [ABAC Overview](./docs/src/orchid/resources/pages/abac.md).
 
 ## Advantages of ABAC
 

--- a/atts/src/main/kotlin/codes/laurence/warden/atts/AttributeType.kt
+++ b/atts/src/main/kotlin/codes/laurence/warden/atts/AttributeType.kt
@@ -41,7 +41,7 @@ data class AttributeType(
     }
 
     /**
-     * Provides the [Attributes] of this type with a single mapping from the typeKeyword to the type.
+     * Provides the [Attributes] of this type with a single mapping from the [typeKeyword] to the [type].
      */
     override fun attributes(): Attributes {
         return mapOf(typeKeyword to type)

--- a/docs/src/orchid/resources/homepage.md
+++ b/docs/src/orchid/resources/homepage.md
@@ -6,7 +6,8 @@ title: 'Home'
 > - Simple and expressive Policy based Authorization
 > - Decoupled from web frameworks
 
-![Build Status](https://github.com/lgwillmore/warden/actions/workflows/test.yml/badge.svg?branch=main) ![version](https://img.shields.io/github/v/tag/lgwillmore/warden?include_prereleases&label=release)
+![Build Status](https://github.com/lgwillmore/warden/actions/workflows/test.yml/badge.svg?branch=main) 
+![version](https://img.shields.io/github/v/tag/lgwillmore/warden?include_prereleases&label=release)
 
 ## What is Attribute Based Access Control?
 
@@ -57,7 +58,7 @@ systems, languages, frontend, backend. It also exposes Policies as business data
 
 ## Planned Features
 
-- Enforcement Point for Spring
+- Enforcement Point for Spring [#27](https://github.com/lgwillmore/warden/issues/27)
 - Tools for CRUDing persistent policies
 - Policy naming
-- More informative responses to allow insight into how a request was approved/denied
+- More informative responses to allow insight into how a request was approved/denied [#25](https://github.com/lgwillmore/warden/issues/25)

--- a/docs/src/orchid/resources/pages/abac.md
+++ b/docs/src/orchid/resources/pages/abac.md
@@ -2,9 +2,11 @@
 title: 'ABAC Overview'
 ---
 
-Attribute Based Access Control (ABAC) is an authorization paradigm that uses policies built around the attributes of a access request.
+Attribute Based Access Control (ABAC) is an authorization paradigm that uses policies built around
+the attributes of an access request.
 
-ABAC is powerful; the more traditional role based authorization approaches can easily be implemented using ABAC, but so can more complex rules.
+ABAC is powerful; the more traditional role based authorization approaches can easily be implemented
+using ABAC, but so can more complex rules.
 
 There are several concepts that define how ABAC achieves this.
 
@@ -12,29 +14,38 @@ There are several concepts that define how ABAC achieves this.
 
 The access request is made up of 4 parts, each with its own attributes:
 
- - **The Subject**: Most often this will represent the user making a request, and examples of the attributes would be 'id', 'roles' etc.
- - **The Action**: The action defines some sort of verb that is being attempted. For example, READ, WRITE, DELETE. But it can also have other attributes like 'Force'
- - **The Resource**: The item that the action is being applied to. This could be any bit of data that can be pointed at by a URL.
- - **The Environment**: Other contextual information about the request, for example the ip address or browser agent.
- 
-By having access to all of this information about the request, we can now define rules and logic to grant access. This is where policies come in.
- 
- ## Policies
- 
-A policy is an encapsulation of a rule or logic that will be able to determine if a given request is authorized. Generally they consist of sets of boolean logica expressions.
- 
- ## Decision Point
- 
-This is some service running either locally or remotely which will have access to all of the needed policies. As such, it is capable of deciding if a given request is authorized. There can be many Policies, and generally things operate on a whitelist basis; if a single policy grants access, then access is granted. If none do, access is not granted
- 
- ## Enforcement Point
- 
+- **The Subject**: Most often this will represent the user making a request, and examples of the
+  attributes would be 'id', 'roles' etc.
+- **The Action**: The action defines some sort of verb that is being attempted. For example, READ,
+  WRITE, DELETE. But it can also have other attributes like 'Force'
+- **The Resource**: The item that the action is being applied to. This could be any bit of data that
+  can be pointed at by a URL.
+- **The Environment**: Other contextual information about the request, for example the ip address or
+  browser agent.
 
-This is a layer or guard around the service that can actually act upon a given request. It will use a `Decision Point` to determine if the request is authorized, and then either allow execution of the request or prevent it.
- 
- ## Information Point
- 
-An information bridge that allows for a `Decision Point` to enhance or fetch any missing attributes for a given access request. For example, the only attribute might be an id, and it is likely that many policies will need more than that to properly function.
- 
- 
+By having access to all of this information about the request, we can now define rules and logic to
+grant access. This is where policies come in.
 
+## Policies
+
+A policy is an encapsulation of a rule or logic that will be able to determine if a given request is
+authorized. Generally they consist of sets of boolean logica expressions.
+
+## Decision Point
+
+This is some service running either locally or remotely which will have access to all the needed
+policies. As such, it is capable of deciding if a given request is authorized. There can be many
+Policies, and generally things operate on a whitelist basis; if a single policy grants access, then
+access is granted. If none do, access is not granted
+
+## Enforcement Point
+
+This is a layer or guard around the service that can actually act upon a given request. It will use
+a `Decision Point` to determine if the request is authorized, and then either allow execution of the
+request or prevent it.
+
+## Information Point
+
+An information bridge that allows for a `Decision Point` to enhance or fetch any missing attributes
+for a given access request. For example, the only attribute might be an id, and it is likely that
+many policies will need more than that to properly function.

--- a/docs/src/orchid/resources/pages/attributes.md
+++ b/docs/src/orchid/resources/pages/attributes.md
@@ -2,18 +2,20 @@
 title: 'Attributes'
 ---
 
-Warden provides some jvm tools for working with the attributes of your data classes and class instances. These tools are
-not required by the core components and are included as a convenience.
+Warden provides some jvm tools for working with the attributes of your data classes and class
+instances. These tools are not required by the core components and are included as a convenience.
 
-## HasAttributesI and Attributes
+## `HasAttributesI` and `Attributes`
 
-The 2 core pieces of the attribute toolset are the `HasAttributesI` interface and a type alias for a Map of
-attributes `Attributes`. This allows us to easily convert the data classes that represent our subjects, actions,
-resource and environment into attributes at any point we are building an `AccessRequest`.
+The 2 core pieces of the attribute toolset are the `HasAttributesI` interface and a type alias for a
+Map of attributes `Attributes`. This allows us to easily convert the data classes that represent our
+subjects, actions, resource and environment into attributes at any point we are building
+an `AccessRequest`.
 
 ### Single Inheritance
 
-The toolset comes with a quick reflection based implementation `HasAttributes`, and its usage is as simple as extending
+The toolset comes with a quick reflection based implementation `HasAttributes`, and its usage is as
+simple as extending
 the class.
 
 ```kotlin
@@ -29,8 +31,9 @@ data class User(
 
 ### Multiple Inheritance
 
-Often, we need to implement multiple interfaces and then need to choose our single concrete implementation. In that case
-there are helpers for easily implementing `HasAttributesI` such as the `attributeOf` function.
+Often, we need to implement multiple interfaces and then need to choose our single concrete
+implementation. In that case there are helpers for easily implementing `HasAttributesI` such as
+the `attributeOf` function.
 
 ```kotlin
 data class UserNew(
@@ -44,20 +47,24 @@ data class UserNew(
 }
 ```
 
-## AttributeType
+## `AttributeType`
 
-It is highly likely that the first and primary attribute that a domain object needs is some sort of `type` attribute. It
-is also highly likely that this type will be shared by several data classes representing different aspects of the same
-domain object. `AttributeType` helps us handle this.
+It is highly likely that the first and primary attribute that a domain object needs is some sort
+of `type` attribute. It is also highly likely that this type will be shared by several data classes
+representing different
+aspects of the same domain object. `AttributeType` helps us handle this.
 
 `AttributeType` takes `type` and an optional `typeKeyword` constructor arguments:
 
 - `type`: A string defining the type of the Attributes
-- `typeKeyword`: Optional aliasing of the key that the type will be mapped to in order to avoid conflicts with other
+- `typeKeyword`: Optional aliasing of the key that the type will be mapped to in order to avoid
+  conflicts with other
   attributes.
 
-`AttributeType` also implements `HasAttributesI` and we can see a usage example below. In particular, it is convenient
-for constructing attributes when we do not have an instance of some domain data class for building an `AccessRequest`.
+`AttributeType` also implements `HasAttributesI` and we can see a usage example below. In
+particular, it is convenient
+for constructing attributes when we do not have an instance of some domain data class for building
+an `AccessRequest`.
 
 ```kotlin
 val USER_TYPE = AttributeType(
@@ -87,13 +94,13 @@ println(
 
 ```
 
-### HasAttributes and AttributeType
+### `HasAttributes` and `AttributeType`
 
-The `AttributeType` can then be used across your `HasAttributesI` implementing data classes as seen in the example
+The `AttributeType` can then be used across your `HasAttributesI` implementing data classes as seen
+in the example
 below.
 
 ```kotlin
-
 val USER_TYPE = AttributeType(
     type = "USER",
     typeKeyword = "authType"
@@ -124,12 +131,13 @@ data class UserNew(
 
 ## Helpers and Extensions
 
-### attributesOf
+### `attributesOf`
 
-The `attributesOf` function is used to recursively and reflectively convert the instance of a class into `Attributes`.
-It will also handle the conversion of aggregates of nested implementers of the `HasAttributesI` interface.
+The `attributesOf` function is used to recursively and reflectively convert the instance of a class
+into `Attributes`. It will also handle the conversion of aggregates of nested implementers of
+the `HasAttributesI` interface.
 
-### withAttributes
+### `withAttributes`
 
-`withAttributes` is an extension function on `HasAttributesI` that lets us conveniently merge other attributes into the
-attributes of the original object.
+`withAttributes` is an extension function on `HasAttributesI` that lets us conveniently merge other
+attributes into the attributes of the original object.

--- a/docs/src/orchid/resources/pages/components.md
+++ b/docs/src/orchid/resources/pages/components.md
@@ -79,7 +79,6 @@ result of the evaluation will depend on:
 previous example.**
 
 ```kotlin
-
 val allowPolicies = listOf<Policy>(
     // Some set of policies
 )
@@ -127,5 +126,3 @@ val enforcementPointFromPolicies = EnforcementPointDefault(
     deny = denyPolicies
 )
 ```
-
-

--- a/docs/src/orchid/resources/pages/faq.md
+++ b/docs/src/orchid/resources/pages/faq.md
@@ -1,12 +1,21 @@
 ---
 title: 'FAQ'
 ---
+
 ### Why are the access requests and policies not typed against actual domain objects with generics?
 
-We are big fans of strong typing, but in the case of defining the attributes for an access request and policies themselves:
+We are big fans of strong typing, but in the case of defining the attributes for an access request
+and policies themselves:
 
- - Very often, you do not need the full Entity to perform a check, a partial set of attributes will be sufficient and efficient.
- - Perhaps you want to assemble attributes for any part of the request from multiple sources
- - Policies may not care about the type of a given Subject, or Resource etc, merely that some id matches for example.
- - We did not want to have complex reflexion logic or generics on the inside of the evaluation boundary.
- - Bags of attributes is what a Subject, Resource, Action, Environment are. Keeping the core logic focused on this will let more complex functionality be built in layers above it. Serialization of entity types to Maps of attributes can happen as an external layer, and validation of policies against known business domain objects can as well. These are things that will likely be built later.
+- Very often, you do not need the full Entity to perform a check, a partial set of attributes will
+  be sufficient and efficient.
+- Perhaps you want to assemble attributes for any part of the request from multiple sources
+- Policies may not care about the type of a given Subject, or Resource etc., merely that some id
+  matches for example.
+- We did not want to have complex reflexion logic or generics on the inside of the evaluation
+  boundary.
+- Bags of attributes is what a Subject, Resource, Action, Environment are. Keeping the core logic
+  focused on this will let more complex functionality be built in layers above it. Serialization of
+  entity types to Maps of attributes can happen as an external layer, and validation of policies
+  against known business domain objects can as well. These are things that will likely be built
+  later.

--- a/docs/src/orchid/resources/pages/installation.md
+++ b/docs/src/orchid/resources/pages/installation.md
@@ -3,6 +3,7 @@
 ![version](https://img.shields.io/github/v/tag/lgwillmore/warden?include_prereleases&label=release)
 
 **Add the repo and core dependency**
+
 ```kotlin
 repositories {
     maven(url = "https://laurencecodes.jfrog.io/artifactory/codes.laurence.warden/")
@@ -13,4 +14,3 @@ dependencies {
     implementation("codes.laurence.warden:warden-core:0.1.0")
 }
 ```
-  

--- a/docs/src/orchid/resources/pages/quick_intro.md
+++ b/docs/src/orchid/resources/pages/quick_intro.md
@@ -2,13 +2,13 @@
 title: 'Quick Intro'
 ---
 
-Let us say we have a blog site and we have the following entities: `User` and `Article`.
+Let us say we have a blog site, and we have the following entities: `User` and `Article`.
 
 We would like the following authorization rules:
 
 - Any `User` can read any `Article`
 - The author of an `Article` can modify and delete their `Article`
-- A `User` must be be an Author to be able to create an article.
+- A `User` must be an Author to be able to create an article.
 
 ## Policies
 
@@ -30,7 +30,7 @@ val policies = listOf(
         action("type") isIn listOf("MODIFY", "DELETE")
         subject("id") equalTo resource("authorID")
     },
-    // A User must be be an Author to be able to create an article.
+    // A User must be an Author to be able to create an article.
     allOf {
         resource("type") equalTo "Article"
         action("type") equalTo "CREATE"
@@ -39,7 +39,7 @@ val policies = listOf(
 )
  ```
 
-Here we have a single `AllOf` policy for each one of our logical desired policies. These each define all of the
+Here we have a single `AllOf` policy for each one of our logical desired policies. These each define all the
 conditions that must be met to satisfy what we want logically.
 
 Now that we have our policies, we can enforce them.
@@ -56,7 +56,6 @@ Let us say we have the following business domain objects, and we are using the W
 provide easy conversion into Maps of attributes.
 
 ```kotlin
-
 data class User(
     val id: String
 ) : HasAttributes()

--- a/docs/src/orchid/resources/pages/web_frameworks.md
+++ b/docs/src/orchid/resources/pages/web_frameworks.md
@@ -3,7 +3,7 @@ title: 'Web Framework Plugins'
 ---
 
 `Warden` is built to be portable with your business logic and not tightly coupled to any particular web framework. But,
-there are concerns for Authorization that are handled very well at an http layer.
+there are concerns for Authorization that are handled very well at a http layer.
 
 If you are serving content and functionality over http, you want to be sure that you have not accidentally left any
 unauthorized doors open.
@@ -64,7 +64,7 @@ fun Application.myWebApplication() {
             /* ----------
              The rest of your routing is wrapped by this block.
              
-             As long as you call the `EnforcementPointKtor` on every route and it allows access, the route will proceed normally.
+             As long as you call the `EnforcementPointKtor` on every route, and it allows access, the route will proceed normally.
              ------------*/
         }
     }
@@ -74,8 +74,8 @@ fun Application.myWebApplication() {
 
 ### Open non-enforced routes
 
-It is often the case that you have routes that do not need to be authorized and should be open. There are 2 ways to
-achieve this.
+It is often the case that you have routes that do not need to be authorized and should be open. 
+There are 2 ways to achieve this.
 
 The easiest is to use an `unwarded` routing block, as demonstrated below.
 
@@ -88,7 +88,7 @@ routing {
             }
             route("public") {
                 unwarded {
-                    // This nested unwarded block is open, even though it has a parent warded block
+                    // This nested un-warded block is open, even though it has a parent warded block
                 }
             }
 
@@ -111,7 +111,7 @@ The first `WardenRoute` to match the route being called is what will determine t
 
 install(Warden) {
     routePriorityStack = listOf(
-        // This top priority route will be unwarded for Post method calls
+        // This top priority route will be un-warded for Post method calls
         WardenRoute("/api/public/.*", WardenRouteBehaviour.IGNORE, setOf(HttpMethod.Post)),
         // This regex route will be enforced for all http methods, but will be superseded by routes above it.
         WardenRoute("/api/.*", WardenRouteBehaviour.ENFORCE),
@@ -151,9 +151,3 @@ routing {
     }
 }
 ```
-
-
-
-
-
-

--- a/docs/src/orchid/resources/pages/web_frameworks.md
+++ b/docs/src/orchid/resources/pages/web_frameworks.md
@@ -88,7 +88,7 @@ routing {
             }
             route("public") {
                 unwarded {
-                    // This nested un-warded block is open, even though it has a parent warded block
+                    // This nested unwarded block is open, even though it has a parent warded block
                 }
             }
 
@@ -111,7 +111,7 @@ The first `WardenRoute` to match the route being called is what will determine t
 
 install(Warden) {
     routePriorityStack = listOf(
-        // This top priority route will be un-warded for Post method calls
+        // This top priority route will be unwarded for Post method calls
         WardenRoute("/api/public/.*", WardenRouteBehaviour.IGNORE, setOf(HttpMethod.Post)),
         // This regex route will be enforced for all http methods, but will be superseded by routes above it.
         WardenRoute("/api/.*", WardenRouteBehaviour.ENFORCE),


### PR DESCRIPTION
Some changes after https://github.com/lgwillmore/warden/pull/35

* minor formatting of Markdown files (shouldn't cause any changes)
* a few spelling/grammar fixes (mostly the same that was previously fixed in the readme https://github.com/lgwillmore/warden/pull/31)
* In the 'planned features' list I added some links to the relevant GitHub issues
