### PR TITLE
Turns core truly multiplatform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.palantir.git-version") version "0.12.3"
+    id("com.google.devtools.ksp") apply false
     buildsrc.convention.ktlint
 }
 
@@ -15,6 +16,6 @@ ktlint {
 }
 
 tasks.wrapper {
-    gradleVersion = "7.4.2"
+    gradleVersion = "8.5"
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,15 +2,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version "1.6.21"
-    // Gradle uses an embedded Kotlin with version 1.4
-    // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-    // but it's safe to use 1.6.21, as long as the language level is set to 1.4
-    // (the kotlin-dsl plugin does this).
+    kotlin("jvm") version "1.9.10"
 }
 
 // set the versions of Gradle plugins that the subprojects will use here
-val kotlinPluginVersion: String = "1.6.21"
+val kotlinPluginVersion: String = "1.9.10"
 val artifactoryPluginVersion: String = "4.28.4"
 val orchidPluginVersion: String = "0.21.1"
 val ktlintPluginVersion: String = "10.3.0"

--- a/buildSrc/repositories.settings.gradle.kts
+++ b/buildSrc/repositories.settings.gradle.kts
@@ -7,6 +7,7 @@ dependencyResolutionManagement {
         jcenter()
         mavenCentral()
         gradlePluginPortal()
+        google()
     }
 
     pluginManagement {
@@ -14,6 +15,11 @@ dependencyResolutionManagement {
             jcenter()
             gradlePluginPortal()
             mavenCentral()
+            google()
+        }
+
+        plugins {
+            id("com.google.devtools.ksp") version "1.9.10-1.0.13" apply false
         }
     }
 }

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kotlin-jvm.gradle.kts
@@ -5,12 +5,6 @@ plugins {
     kotlin("jvm")
 }
 
-kotlin {
-    jvmToolchain {
-        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of("8"))
-    }
-}
-
 java {
     withSourcesJar()
     withJavadocJar()

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,34 +1,38 @@
 plugins {
     buildsrc.convention.`kotlin-multiplatform`
     buildsrc.convention.`sonatype-publish`
+    id("com.google.devtools.ksp")
 }
 
 val assertKVersion: String by project
 val mockkVersion: String by project
+val mockativeVersion: String by project
 val kotlinVersion: String by project
 
 kotlin {
+    targetHierarchy.default()
 
     jvm()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
             }
         }
         val commonTest by getting {
             dependencies {
+                implementation(kotlin("test-junit"))
                 implementation(kotlin("test"))
-                implementation("io.mockk:mockk:$mockkVersion")
-                implementation("com.willowtreeapps.assertk:assertk:$assertKVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+                implementation("io.mockative:mockative:$mockativeVersion")
             }
         }
 
         val jvmMain by getting {
-            // Default source set for JVM-specific sources and dependencies:
-            dependencies {
-            }
+            dependsOn(commonMain)
         }
 
         val jvmTest by getting {
@@ -37,5 +41,33 @@ kotlin {
                 implementation(kotlin("test-junit"))
             }
         }
+
+        val nativeMain by getting {
+            dependsOn(commonMain)
+        }
+
+        val nativeTest by getting {
+            dependsOn(commonTest)
+        }
     }
 }
+
+dependencies {
+    configurations
+        .filter { it.name.startsWith("ksp") && it.name.contains("Test") }
+        .forEach {
+            add(it.name, "io.mockative:mockative-processor:$mockativeVersion")
+        }
+}
+
+ktlint {
+    filter {
+        include { element ->
+            element.file.extension in setOf("kt", "kts")
+        }
+        exclude { element ->
+            element.file.path.contains("generated") || element.file.name == "build.gradle.kts"
+        }
+    }
+}
+

--- a/core/src/commonTest/kotlin/codes/laurence/warden/decision/DecisionPointLocalTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/decision/DecisionPointLocalTest.kt
@@ -1,7 +1,5 @@
 package codes.laurence.warden.decision
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 import codes.laurence.warden.Access
 import codes.laurence.warden.AccessRequest
 import codes.laurence.warden.AccessRequestBatch
@@ -10,189 +8,223 @@ import codes.laurence.warden.coroutines.runBlockingTest
 import codes.laurence.warden.information.InformationPoint
 import codes.laurence.warden.policy.Policy
 import codes.laurence.warden.test.attributesFixture
-import io.mockk.coEvery
-import io.mockk.coVerifySequence
-import io.mockk.every
-import io.mockk.mockk
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.every
+import io.mockative.mock
+import kotlinx.coroutines.runBlocking
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-val accessRequest = AccessRequest().copy(
-    action = mapOf("foo" to "bar")
-)
-val enrichedRequest = AccessRequest().copy(
-    action = mapOf("foo" to "enriched")
-)
-val informationPointMock = mockk<InformationPoint> {
-    coEvery { enrich(accessRequest) } returns enrichedRequest
-}
-
-val denial = AccessResponse(Access.Denied(), accessRequest)
-val granted = AccessResponse(Access.Granted(), accessRequest)
-
-val willAuthorizePolicy = mockk<Policy> {
-    every { checkAuthorized(accessRequest) } returns granted
-    every { checkAuthorized(enrichedRequest) } returns AccessResponse(Access.Granted(), enrichedRequest)
-}
-val willNotAuthorizePolicy = mockk<Policy> {
-    every { checkAuthorized(accessRequest) } returns denial
-    every { checkAuthorized(enrichedRequest) } returns AccessResponse(Access.Granted(), enrichedRequest)
-}
-
 class DecisionPointLocalTest {
-
-    @Test
-    fun `checkAuthorised - enriches before decision`() = runBlockingTest {
-        val accessPolicyMock = willAuthorizePolicy
-        val denyPolicyMock = willNotAuthorizePolicy
-
-        val testObj = DecisionPointLocal(
-            allow = listOf(accessPolicyMock),
-            deny = listOf(denyPolicyMock),
-            informationPoint = informationPointMock
+    private val accessRequest =
+        AccessRequest().copy(
+            action = mapOf("foo" to "bar"),
+        )
+    private val enrichedRequest =
+        AccessRequest().copy(
+            action = mapOf("foo" to "enriched"),
         )
 
-        testObj.checkAuthorized(accessRequest)
+    @Mock
+    val informationPointMock = mock(classOf<InformationPoint>())
 
-        coVerifySequence {
-            informationPointMock.enrich(accessRequest)
-            accessPolicyMock.checkAuthorized(enrichedRequest)
-            denyPolicyMock.checkAuthorized(enrichedRequest)
+    private val denial = AccessResponse(Access.Denied(), accessRequest)
+    private val granted = AccessResponse(Access.Granted(), accessRequest)
+
+    @Mock
+    val willAuthorizePolicy = mock(classOf<Policy>())
+
+    @Mock
+    val willNotAuthorizePolicy = mock(classOf<Policy>())
+
+    @Mock
+    val allowResource1Policy = mock(classOf<Policy>())
+
+    @BeforeTest
+    fun beforeEachTest() =
+        runBlocking {
+            coEvery { informationPointMock.enrich(accessRequest) }.returns(enrichedRequest)
+
+            every { willAuthorizePolicy.checkAuthorized(accessRequest) }.returns(granted)
+            every { willAuthorizePolicy.checkAuthorized(enrichedRequest) }.returns(AccessResponse(Access.Granted(), enrichedRequest))
+
+            every { willNotAuthorizePolicy.checkAuthorized(accessRequest) }.returns(denial)
+            every { willNotAuthorizePolicy.checkAuthorized(enrichedRequest) }.returns(AccessResponse(Access.Granted(), enrichedRequest))
         }
-    }
 
     @Test
-    fun checkAuthorized_emptyPolicies() = runBlockingTest {
-        assertEquals(
-            AccessResponse(
-                access = Access.Denied(),
-                request = accessRequest
-            ),
-            DecisionPointLocal(
-                allow = emptyList()
-            ).checkAuthorized(accessRequest)
-        )
-    }
+    fun `checkAuthorised - enriches before decision`() =
+        runBlockingTest {
+            val accessPolicyMock = willAuthorizePolicy
+            val denyPolicyMock = willNotAuthorizePolicy
 
-    @Test
-    fun checkAuthorized_atLeastOneAuthorized() = runBlockingTest {
-        assertEquals(
-            granted,
-            DecisionPointLocal(
-                allow = listOf(
-                    willNotAuthorizePolicy,
-                    willNotAuthorizePolicy,
-                    willAuthorizePolicy,
-                    willNotAuthorizePolicy
+            val testObj =
+                DecisionPointLocal(
+                    allow = listOf(accessPolicyMock),
+                    deny = listOf(denyPolicyMock),
+                    informationPoint = informationPointMock,
                 )
-            ).checkAuthorized(accessRequest)
-        )
-    }
+
+            testObj.checkAuthorized(accessRequest)
+
+            coVerify {
+                informationPointMock.enrich(accessRequest)
+                accessPolicyMock.checkAuthorized(enrichedRequest)
+                denyPolicyMock.checkAuthorized(enrichedRequest)
+            }.wasInvoked()
+        }
 
     @Test
-    fun checkAuthorized_allAuthorized() = runBlockingTest {
-        assertEquals(
-            granted,
-            DecisionPointLocal(
-                allow = listOf(
-                    willAuthorizePolicy,
-                    willAuthorizePolicy,
-                    willAuthorizePolicy
-                )
-            ).checkAuthorized(accessRequest)
-        )
-    }
-
-    @Test
-    fun checkAuthorized_NoneAuthorized() = runBlockingTest {
-        assertEquals(
-            denial,
-            DecisionPointLocal(
-                allow = listOf(
-                    willNotAuthorizePolicy,
-                    willNotAuthorizePolicy,
-                    willNotAuthorizePolicy
-                )
-            ).checkAuthorized(accessRequest)
-        )
-    }
-
-    @Test
-    fun checkAuthorized_atLeastOneAuthorized_alsoDenied() = runBlockingTest {
-        assertEquals(
-            denial,
-            DecisionPointLocal(
-                allow = listOf(
-                    willNotAuthorizePolicy,
-                    willNotAuthorizePolicy,
-                    willAuthorizePolicy,
-                    willNotAuthorizePolicy
+    fun checkAuthorized_emptyPolicies() =
+        runBlockingTest {
+            assertEquals(
+                AccessResponse(
+                    access = Access.Denied(),
+                    request = accessRequest,
                 ),
-                deny = listOf(
-                    willAuthorizePolicy
-                )
-            ).checkAuthorized(accessRequest)
-        )
-    }
+                DecisionPointLocal(
+                    allow = emptyList(),
+                ).checkAuthorized(accessRequest),
+            )
+        }
 
     @Test
-    fun checkAuthorized_atLeastOneAuthorized_notDenied() = runBlockingTest {
-        assertEquals(
-            granted,
-            DecisionPointLocal(
-                allow = listOf(
-                    willNotAuthorizePolicy,
-                    willNotAuthorizePolicy,
-                    willAuthorizePolicy,
-                    willNotAuthorizePolicy
-                ),
-                deny = listOf(
-                    willNotAuthorizePolicy
-                )
-            ).checkAuthorized(accessRequest)
-        )
-    }
+    fun checkAuthorized_atLeastOneAuthorized() =
+        runBlockingTest {
+            assertEquals(
+                granted,
+                DecisionPointLocal(
+                    allow =
+                    listOf(
+                        willNotAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                        willAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                    ),
+                ).checkAuthorized(accessRequest),
+            )
+        }
+
+    @Test
+    fun checkAuthorized_allAuthorized() =
+        runBlockingTest {
+            assertEquals(
+                granted,
+                DecisionPointLocal(
+                    allow =
+                    listOf(
+                        willAuthorizePolicy,
+                        willAuthorizePolicy,
+                        willAuthorizePolicy,
+                    ),
+                ).checkAuthorized(accessRequest),
+            )
+        }
+
+    @Test
+    fun checkAuthorized_NoneAuthorized() =
+        runBlockingTest {
+            assertEquals(
+                denial,
+                DecisionPointLocal(
+                    allow =
+                    listOf(
+                        willNotAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                    ),
+                ).checkAuthorized(accessRequest),
+            )
+        }
+
+    @Test
+    fun checkAuthorized_atLeastOneAuthorized_alsoDenied() =
+        runBlockingTest {
+            assertEquals(
+                denial,
+                DecisionPointLocal(
+                    allow =
+                    listOf(
+                        willNotAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                        willAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                    ),
+                    deny =
+                    listOf(
+                        willAuthorizePolicy,
+                    ),
+                ).checkAuthorized(accessRequest),
+            )
+        }
+
+    @Test
+    fun checkAuthorized_atLeastOneAuthorized_notDenied() =
+        runBlockingTest {
+            assertEquals(
+                granted,
+                DecisionPointLocal(
+                    allow =
+                    listOf(
+                        willNotAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                        willAuthorizePolicy,
+                        willNotAuthorizePolicy,
+                    ),
+                    deny =
+                    listOf(
+                        willNotAuthorizePolicy,
+                    ),
+                ).checkAuthorized(accessRequest),
+            )
+        }
 
     @Test
     fun checkAuthorizedBatch() {
         val resource1 = attributesFixture()
         val resource2 = attributesFixture()
-        val request = AccessRequestBatch(
-            subject = attributesFixture(),
-            action = attributesFixture(),
-            environment = attributesFixture(),
-            resources = listOf(resource1, resource2)
-        )
+        val request =
+            AccessRequestBatch(
+                subject = attributesFixture(),
+                action = attributesFixture(),
+                environment = attributesFixture(),
+                resources = listOf(resource1, resource2),
+            )
 
-        val request1 = AccessRequest(
-            subject = request.subject,
-            action = request.action,
-            environment = request.environment,
-            resource = resource1
-        )
+        val request1 =
+            AccessRequest(
+                subject = request.subject,
+                action = request.action,
+                environment = request.environment,
+                resource = resource1,
+            )
         val response1 = AccessResponse(access = Access.Granted(), request1)
 
-        val request2 = AccessRequest(
-            subject = request.subject,
-            action = request.action,
-            environment = request.environment,
-            resource = resource2
-        )
+        val request2 =
+            AccessRequest(
+                subject = request.subject,
+                action = request.action,
+                environment = request.environment,
+                resource = resource2,
+            )
         val response2 = AccessResponse(access = Access.Denied(), request2)
 
-        val allowResource1Policy = mockk<Policy> {
-            every { checkAuthorized(request1) } returns response1
-            every { checkAuthorized(request2) } returns response2
-        }
+        every { allowResource1Policy.checkAuthorized(request1) }.returns(response1)
+        every { allowResource1Policy.checkAuthorized(request2) }.returns(response2)
 
-        val testObj = DecisionPointLocal(
-            allow = listOf(allowResource1Policy)
-        )
+        val testObj =
+            DecisionPointLocal(
+                allow = listOf(allowResource1Policy),
+            )
 
         runBlockingTest {
             val actual = testObj.checkAuthorizedBatch(request)
 
-            assertThat(actual).isEqualTo(listOf(response1, response2))
+            assertEquals(listOf(response1, response2), actual)
         }
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/enforce/EnforcementPointDefaultTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/enforce/EnforcementPointDefaultTest.kt
@@ -1,150 +1,165 @@
 package codes.laurence.warden.enforce
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
-import codes.laurence.warden.*
+import codes.laurence.warden.Access
+import codes.laurence.warden.AccessRequest
+import codes.laurence.warden.AccessRequestBatch
+import codes.laurence.warden.AccessResponse
+import codes.laurence.warden.FilterAccessRequest
+import codes.laurence.warden.ResourceAttributePair
 import codes.laurence.warden.coroutines.runBlockingTest
 import codes.laurence.warden.decision.DecisionPoint
 import codes.laurence.warden.policy.expression.Exp
 import codes.laurence.warden.test.attributesFixture
-import io.mockk.coEvery
-import io.mockk.mockk
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.coEvery
+import io.mockative.mock
+import kotlinx.coroutines.runBlocking
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 class EnforcementPointDefaultTest {
+    private val deniedRequest =
+        AccessRequest(
+            subject = mapOf("foo" to "denied"),
+        )
+
+    private val grantedRequest =
+        AccessRequest(
+            subject = mapOf("foo" to "granted"),
+        )
+
+    private val resources =
+        List(10) { index ->
+            ResourceAttributePair(
+                resource = ArbitraryResource(index),
+                attributes = mapOf("index" to index),
+            )
+        }
+    private val request =
+        FilterAccessRequest(
+            subject = attributesFixture(),
+            action = attributesFixture(),
+            resources = resources,
+            environment = attributesFixture(),
+        )
+
+    private val responses =
+        resources.map {
+            val granted = listOf(true, false).random()
+            if (granted) {
+                AccessResponse(
+                    access = Access.Granted(),
+                    request =
+                    AccessRequest(
+                        subject = request.subject,
+                        action = request.action,
+                        resource = it.attributes,
+                        environment = request.environment,
+                    ),
+                )
+            } else {
+                AccessResponse(
+                    access = Access.Denied(),
+                    request =
+                    AccessRequest(
+                        subject = request.subject,
+                        action = request.action,
+                        resource = it.attributes,
+                        environment = request.environment,
+                    ),
+                )
+            }
+        }
+
+    @Mock
+    val decisionPointMock = mock(classOf<DecisionPoint>())
+
+    @BeforeTest
+    fun beforeEachTest() = runBlocking {
+        coEvery { decisionPointMock.checkAuthorized(deniedRequest) }.returns(
+            AccessResponse(
+                access = Access.Denied(),
+                request =
+                AccessRequest(
+                    subject = mapOf("foo" to "returned"),
+                ),
+            ),
+        )
+
+        coEvery { decisionPointMock.checkAuthorized(grantedRequest) }.returns(
+            AccessResponse(
+                access = Access.Granted(),
+                request =
+                AccessRequest(
+                    subject = mapOf("foo" to "returned"),
+                ),
+            ),
+        )
+
+        coEvery {
+            decisionPointMock.checkAuthorizedBatch(
+                AccessRequestBatch(
+                    subject = request.subject,
+                    action = request.action,
+                    resources = request.resources.map { it.attributes },
+                    environment = request.environment,
+                ),
+            )
+        }.returns(responses)
+    }
 
     @Test
     fun `constructor - list of policies`() {
         val policies = listOf(Exp.action("foo") equalTo "bar")
         val testObj = EnforcementPointDefault(policies)
 
-        assertThat(testObj.decisionPoint).isInstanceOf(DecisionPoint::class)
+        assertIs<DecisionPoint>(testObj.decisionPoint)
     }
 
     @Test
     fun `enforceAuthorization - Denied`() {
-
-        val request = AccessRequest(
-            subject = mapOf("foo" to "bar")
-        )
-
-        val deniedResponse = AccessResponse(
-            access = Access.Denied(),
-            request = AccessRequest(
-                subject = mapOf("foo" to "returned")
-            )
-        )
-
-        val decisionPointMock = mockk<DecisionPoint> {
-            coEvery { checkAuthorized(request) } returns deniedResponse
-        }
-
         val testObj = EnforcementPointDefault(decisionPointMock)
 
         assertFailsWith(NotAuthorizedException::class) {
             runBlockingTest {
-                testObj.enforceAuthorization(request)
+                testObj.enforceAuthorization(deniedRequest)
             }
         }
     }
 
     @Test
     fun `enforceAuthorization - Granted`() {
-
-        val request = AccessRequest(
-            subject = mapOf("foo" to "bar")
-        )
-
-        val grantedResponse = AccessResponse(
-            access = Access.Granted(),
-            request = AccessRequest(
-                subject = mapOf("foo" to "returned")
-            )
-        )
-
-        val decisionPointMock = mockk<DecisionPoint> {
-            coEvery { checkAuthorized(request) } returns grantedResponse
-        }
-
         val testObj = EnforcementPointDefault(decisionPointMock)
 
         runBlockingTest {
-            testObj.enforceAuthorization(request)
+            testObj.enforceAuthorization(grantedRequest)
         }
     }
 
     @Test
     fun filterAuthorization() {
-        val resources = List(10) { index ->
-            ResourceAttributePair(
-                resource = ArbitraryResource(index),
-                attributes = mapOf("index" to index)
-            )
-        }
-        val request = FilterAccessRequest(
-            subject = attributesFixture(),
-            action = attributesFixture(),
-            resources = resources,
-            environment = attributesFixture()
-        )
-
-        val responses = resources.map {
-            val granted = listOf(true, false).random()
-            if (granted) {
-                AccessResponse(
-                    access = Access.Granted(),
-                    request = AccessRequest(
-                        subject = request.subject,
-                        action = request.action,
-                        resource = it.attributes,
-                        environment = request.environment
-                    )
-                )
-            } else {
-                AccessResponse(
-                    access = Access.Denied(),
-                    request = AccessRequest(
-                        subject = request.subject,
-                        action = request.action,
-                        resource = it.attributes,
-                        environment = request.environment
-                    )
-                )
+        val expectedResult =
+            resources.mapIndexedNotNull { index, resourceAttributePair ->
+                when (responses[index].access) {
+                    is Access.Granted -> resourceAttributePair.resource
+                    else -> null
+                }
             }
-        }
-
-        val decisionPointMock = mockk<DecisionPoint> {
-            coEvery {
-                checkAuthorizedBatch(
-                    AccessRequestBatch(
-                        subject = request.subject,
-                        action = request.action,
-                        resources = request.resources.map { it.attributes },
-                        environment = request.environment
-                    )
-                )
-            } returns responses
-        }
-
-        val expectedResult = resources.mapIndexedNotNull { index, resourceAttributePair ->
-            when (responses[index].access) {
-                is Access.Granted -> resourceAttributePair.resource
-                else -> null
-            }
-        }
 
         val testObj = EnforcementPointDefault(decisionPointMock)
 
         runBlockingTest {
             val actual = testObj.filterAuthorization(request)
 
-            assertThat(actual).isEqualTo(expectedResult)
+            assertEquals(expectedResult, actual)
         }
     }
 }
 
 private data class ArbitraryResource(
-    val counter: Int
+    val counter: Int,
 )

--- a/core/src/commonTest/kotlin/codes/laurence/warden/information/InformationPointPassThroughTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/information/InformationPointPassThroughTest.kt
@@ -1,25 +1,25 @@
 package codes.laurence.warden.information
 
-import assertk.assertThat
-import assertk.assertions.isSameAs
 import codes.laurence.warden.AccessRequest
 import codes.laurence.warden.coroutines.runBlockingTest
 import kotlin.test.Test
+import kotlin.test.assertSame
 
 class InformationPointPassThroughTest {
-
     @Test
-    fun enrich() = runBlockingTest {
-        val request = AccessRequest(
-            subject = mapOf("1" to 1),
-            action = mapOf("1" to 2),
-            resource = mapOf("1" to 3),
-            environment = mapOf("1" to 4),
-        )
-        val testObj = InformationPointPassThrough()
+    fun enrich() =
+        runBlockingTest {
+            val request =
+                AccessRequest(
+                    subject = mapOf("1" to 1),
+                    action = mapOf("1" to 2),
+                    resource = mapOf("1" to 3),
+                    environment = mapOf("1" to 4),
+                )
+            val testObj = InformationPointPassThrough()
 
-        val actual = testObj.enrich(request)
+            val actual = testObj.enrich(request)
 
-        assertThat(actual).isSameAs(request)
-    }
+            assertSame(request, actual)
+        }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/PolicySourceInMemoryTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/PolicySourceInMemoryTest.kt
@@ -1,30 +1,30 @@
 package codes.laurence.warden.policy
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 import codes.laurence.warden.coroutines.runBlockingTest
 import codes.laurence.warden.test.accessRequestFixture
 import codes.laurence.warden.test.expressionPolicyFixture
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class PolicySourceInMemoryTest {
-
     @Test
     fun policies() {
         runBlockingTest {
-            val expected = Policies(
-                allow = listOf(expressionPolicyFixture()),
-                deny = listOf(expressionPolicyFixture())
-            )
+            val expected =
+                Policies(
+                    allow = listOf(expressionPolicyFixture()),
+                    deny = listOf(expressionPolicyFixture()),
+                )
 
-            val testObj = PolicySourceInMemory(
-                allow = expected.allow,
-                deny = expected.deny
-            )
+            val testObj =
+                PolicySourceInMemory(
+                    allow = expected.allow,
+                    deny = expected.deny,
+                )
 
             val actual = testObj.policies(accessRequestFixture())
 
-            assertThat(actual).isEqualTo(expected)
+            assertEquals(expected, actual)
         }
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/assertions.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/assertions.kt
@@ -1,13 +1,16 @@
 package codes.laurence.warden.policy
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 import codes.laurence.warden.policy.expression.AttributeReference
 import codes.laurence.warden.policy.expression.AttributeType
 import codes.laurence.warden.policy.expression.ExpressionPolicy
+import kotlin.test.assertEquals
 
-fun assertLeftOperand(policy: ExpressionPolicy, expectedType: AttributeType, expectedPath: List<String>) {
+fun assertLeftOperand(
+    policy: ExpressionPolicy,
+    expectedType: AttributeType,
+    expectedPath: List<String>,
+) {
     val leftOperand = policy.leftOperand as AttributeReference
-    assertThat(leftOperand.type).isEqualTo(expectedType)
-    assertThat(leftOperand.path).isEqualTo(expectedPath)
+    assertEquals(expectedType, leftOperand.type)
+    assertEquals(expectedPath, leftOperand.path)
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/bool/BooleanDSLTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/bool/BooleanDSLTest.kt
@@ -1,15 +1,13 @@
 package codes.laurence.warden.policy.bool
 
-import assertk.assertThat
-import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotEmpty
-import codes.laurence.warden.policy.*
+import codes.laurence.warden.policy.assertLeftOperand
 import codes.laurence.warden.policy.expression.AttributeType
 import codes.laurence.warden.policy.expression.ExpressionPolicy
 import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
-class CollectionBasedBuildersTest {
-
+class BooleanDSLTest {
     @Test
     fun `leftOperand - Subject`() {
         val key = "key1"
@@ -40,33 +38,37 @@ class CollectionBasedBuildersTest {
 
     @Test
     fun `nested - anyOf`() {
-        val policy = allOf {
-            anyOf { environment("foo") equalTo 1 }
-        }
-        assertThat((policy.policies[0] as AnyOf).policies).isNotEmpty()
+        val policy =
+            allOf {
+                anyOf { environment("foo") equalTo 1 }
+            }
+        assertTrue(((policy.policies[0] as AnyOf).policies).isNotEmpty())
     }
 
     @Test
     fun `nested - allOf`() {
-        val policy = allOf {
-            allOf { environment("foo") equalTo 1 }
-        }
-        assertThat((policy.policies[0] as AllOf).policies).isNotEmpty()
+        val policy =
+            allOf {
+                allOf { environment("foo") equalTo 1 }
+            }
+        assertTrue(((policy.policies[0] as AllOf).policies).isNotEmpty())
     }
 
     @Test
     fun `nested - notAnyOf`() {
-        val policy = allOf {
-            notAnyOf { environment("foo") equalTo 1 }
-        }
-        assertThat((policy.policies[0] as Not).policy).isInstanceOf(AnyOf::class)
+        val policy =
+            allOf {
+                notAnyOf { environment("foo") equalTo 1 }
+            }
+        assertIs<AnyOf>((policy.policies[0] as Not).policy)
     }
 
     @Test
     fun `nested - notAllOf`() {
-        val policy = allOf {
-            notAllOf { environment("foo") equalTo 1 }
-        }
-        assertThat((policy.policies[0] as Not).policy).isInstanceOf(AllOf::class)
+        val policy =
+            allOf {
+                notAllOf { environment("foo") equalTo 1 }
+            }
+        assertIs<AllOf>((policy.policies[0] as Not).policy)
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/bool/BooleanPolicyTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/bool/BooleanPolicyTest.kt
@@ -4,33 +4,51 @@ import codes.laurence.warden.Access
 import codes.laurence.warden.AccessRequest
 import codes.laurence.warden.AccessResponse
 import codes.laurence.warden.policy.Policy
-import io.mockk.every
-import io.mockk.mockk
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.every
+import io.mockative.mock
+import kotlinx.coroutines.runBlocking
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-val accessRequest = AccessRequest().copy(
-    action = mapOf("foo" to "bar")
-)
-val willAuthorizePolicy = mockk<Policy> {
-    every { checkAuthorized(accessRequest) } returns AccessResponse(Access.Granted(), accessRequest)
-}
+val accessRequest =
+    AccessRequest().copy(
+        action = mapOf("foo" to "bar"),
+    )
+
+@Mock
+val willAuthorizePolicy = mock(classOf<Policy>())
 val denial = AccessResponse(Access.Denied(mapOf("arbitrary" to "denial")), accessRequest)
 val granted = AccessResponse(Access.Granted(), accessRequest)
-val willNotAuthorizePolicy = mockk<Policy> {
-    every { checkAuthorized(accessRequest) } returns denial
-}
+
+@Mock
+val willNotAuthorizePolicy = mock(classOf<Policy>())
 
 class AllOfTest {
+
+    @BeforeTest
+    fun beforeEachTest() =
+        runBlocking {
+            every { willAuthorizePolicy.checkAuthorized(accessRequest) }.returns(
+                AccessResponse(
+                    Access.Granted(),
+                    accessRequest,
+                ),
+            )
+
+            every { willNotAuthorizePolicy.checkAuthorized(accessRequest) }.returns(denial)
+        }
 
     @Test
     fun checkAuthorized_emptyPolicies() {
         assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
+                request = accessRequest,
             ),
-            AllOf().checkAuthorized(accessRequest)
+            AllOf().checkAuthorized(accessRequest),
         )
     }
 
@@ -42,8 +60,8 @@ class AllOfTest {
                 willAuthorizePolicy,
                 willAuthorizePolicy,
                 willNotAuthorizePolicy,
-                willAuthorizePolicy
-            ).checkAuthorized(accessRequest)
+                willAuthorizePolicy,
+            ).checkAuthorized(accessRequest),
         )
     }
 
@@ -54,8 +72,8 @@ class AllOfTest {
             AllOf(
                 willAuthorizePolicy,
                 willAuthorizePolicy,
-                willAuthorizePolicy
-            ).checkAuthorized(accessRequest)
+                willAuthorizePolicy,
+            ).checkAuthorized(accessRequest),
         )
     }
 
@@ -66,22 +84,21 @@ class AllOfTest {
             AllOf(
                 willNotAuthorizePolicy,
                 willNotAuthorizePolicy,
-                willNotAuthorizePolicy
-            ).checkAuthorized(accessRequest)
+                willNotAuthorizePolicy,
+            ).checkAuthorized(accessRequest),
         )
     }
 }
 
 class AnyOfTest {
-
     @Test
     fun checkAuthorized_emptyPolicies() {
         assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
+                request = accessRequest,
             ),
-            AnyOf().checkAuthorized(accessRequest)
+            AnyOf().checkAuthorized(accessRequest),
         )
     }
 
@@ -93,8 +110,8 @@ class AnyOfTest {
                 willAuthorizePolicy,
                 willAuthorizePolicy,
                 willNotAuthorizePolicy,
-                willAuthorizePolicy
-            ).checkAuthorized(accessRequest)
+                willAuthorizePolicy,
+            ).checkAuthorized(accessRequest),
         )
     }
 
@@ -105,8 +122,8 @@ class AnyOfTest {
             AnyOf(
                 willAuthorizePolicy,
                 willAuthorizePolicy,
-                willAuthorizePolicy
-            ).checkAuthorized(accessRequest)
+                willAuthorizePolicy,
+            ).checkAuthorized(accessRequest),
         )
     }
 
@@ -115,24 +132,23 @@ class AnyOfTest {
         assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
+                request = accessRequest,
             ),
             AnyOf(
                 willNotAuthorizePolicy,
                 willNotAuthorizePolicy,
-                willNotAuthorizePolicy
-            ).checkAuthorized(accessRequest)
+                willNotAuthorizePolicy,
+            ).checkAuthorized(accessRequest),
         )
     }
 }
 
 class NotTest {
-
     @Test
     fun checkAuthorized_isWhenInnerIsNot() {
         assertEquals(
             denial.copy(access = Access.Granted()),
-            Not(willNotAuthorizePolicy).checkAuthorized(accessRequest)
+            Not(willNotAuthorizePolicy).checkAuthorized(accessRequest),
         )
     }
 
@@ -140,7 +156,7 @@ class NotTest {
     fun checkAuthorized_isNotWhenInnerIs() {
         assertEquals(
             granted.copy(access = Access.Denied()),
-            Not(willAuthorizePolicy).checkAuthorized(accessRequest)
+            Not(willAuthorizePolicy).checkAuthorized(accessRequest),
         )
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/expression/ExpressionDSLTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/expression/ExpressionDSLTest.kt
@@ -1,12 +1,10 @@
 package codes.laurence.warden.policy.expression
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 import codes.laurence.warden.policy.assertLeftOperand
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
-class ExpTest {
-
+class ExpressionDSLTest {
     @Test
     fun `leftOperand - Subject`() {
         val key = "key1"
@@ -75,7 +73,7 @@ class ExpTest {
         val value = 2
         val policy = Exp.subject("blah") equalTo value
         val rightOperand = policy.rightOperand as PassThroughReference
-        assertThat(rightOperand.value).isEqualTo(value)
+        assertEquals(value, rightOperand.value)
     }
 
     @Test
@@ -85,105 +83,109 @@ class ExpTest {
         assertRightOperand(policy, AttributeType.ENVIRONMENT, expectedPath)
     }
 
-    private fun assertRightOperand(policy: ExpressionPolicy, expectedType: AttributeType, expectedPath: List<String>) {
+    private fun assertRightOperand(
+        policy: ExpressionPolicy,
+        expectedType: AttributeType,
+        expectedPath: List<String>,
+    ) {
         val rightOperand = policy.rightOperand as AttributeReference
-        assertThat(rightOperand.type).isEqualTo(expectedType)
-        assertThat(rightOperand.path).isEqualTo(expectedPath)
+        assertEquals(expectedType, rightOperand.type)
+        assertEquals(expectedPath, rightOperand.path)
     }
 
     @Test
     fun `operator - equalTo`() {
         val policy = Exp.subject("blah") equalTo 1
-        assertThat(policy.operatorType).isEqualTo(OperatorType.EQUAL)
+        assertEquals(OperatorType.EQUAL, policy.operatorType)
     }
 
     @Test
     fun `operator - greaterThan - value`() {
         val policy = Exp.subject("blah") greaterThan 1
-        assertThat(policy.operatorType).isEqualTo(OperatorType.GREATER_THAN)
+        assertEquals(OperatorType.GREATER_THAN, policy.operatorType)
     }
 
     @Test
     fun `operator - greaterThan - attribute`() {
         val policy = Exp.subject("blah") greaterThan subjectVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.GREATER_THAN)
+        assertEquals(OperatorType.GREATER_THAN, policy.operatorType)
     }
 
     @Test
     fun `operator - greaterThanEqual - value`() {
         val policy = Exp.subject("blah") greaterThanEqual 1
-        assertThat(policy.operatorType).isEqualTo(OperatorType.GREATER_THAN_EQUAL)
+        assertEquals(OperatorType.GREATER_THAN_EQUAL, policy.operatorType)
     }
 
     @Test
     fun `operator - greaterThanEqual - attribute`() {
         val policy = Exp.subject("blah") greaterThanEqual subjectVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.GREATER_THAN_EQUAL)
+        assertEquals(OperatorType.GREATER_THAN_EQUAL, policy.operatorType)
     }
 
     @Test
     fun `operator - lessThanEqual - value`() {
         val policy = Exp.subject("blah") lessThanEqual 1
-        assertThat(policy.operatorType).isEqualTo(OperatorType.LESS_THAN_EQUAL)
+        assertEquals(OperatorType.LESS_THAN_EQUAL, policy.operatorType)
     }
 
     @Test
     fun `operator - lessThanEqual - attribute`() {
         val policy = Exp.subject("blah") lessThanEqual subjectVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.LESS_THAN_EQUAL)
+        assertEquals(OperatorType.LESS_THAN_EQUAL, policy.operatorType)
     }
 
     @Test
     fun `operator - lessThan - value`() {
         val policy = Exp.subject("blah") lessThan 1
-        assertThat(policy.operatorType).isEqualTo(OperatorType.LESS_THAN)
+        assertEquals(OperatorType.LESS_THAN, policy.operatorType)
     }
 
     @Test
     fun `operator - lessThan - attribute`() {
         val policy = Exp.subject("blah") lessThan subjectVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.LESS_THAN)
+        assertEquals(OperatorType.LESS_THAN, policy.operatorType)
     }
 
     @Test
     fun `operator - contains`() {
         val policy = Exp.subject("blah") contains 1
-        assertThat(policy.operatorType).isEqualTo(OperatorType.CONTAINS)
+        assertEquals(OperatorType.CONTAINS, policy.operatorType)
     }
 
     @Test
     fun `operator - containsAll - value`() {
         val policy = Exp.subject("blah") containsAll listOf(1)
-        assertThat(policy.operatorType).isEqualTo(OperatorType.CONTAINS_ALL)
+        assertEquals(OperatorType.CONTAINS_ALL, policy.operatorType)
     }
 
     @Test
     fun `operator - containsAll - attribute`() {
         val policy = Exp.subject("blah") containsAll resourceVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.CONTAINS_ALL)
+        assertEquals(OperatorType.CONTAINS_ALL, policy.operatorType)
     }
 
     @Test
     fun `operator - containsAny - value`() {
         val policy = Exp.subject("blah") containsAny listOf(1)
-        assertThat(policy.operatorType).isEqualTo(OperatorType.CONTAINS_ANY)
+        assertEquals(OperatorType.CONTAINS_ANY, policy.operatorType)
     }
 
     @Test
     fun `operator - containsAny - attribute`() {
         val policy = Exp.subject("blah") containsAny resourceVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.CONTAINS_ANY)
+        assertEquals(OperatorType.CONTAINS_ANY, policy.operatorType)
     }
 
     @Test
     fun `operator - isIn - value`() {
         val policy = Exp.subject("blah") isIn listOf(1)
-        assertThat(policy.operatorType).isEqualTo(OperatorType.IS_IN)
+        assertEquals(OperatorType.IS_IN, policy.operatorType)
     }
 
     @Test
     fun `operator - isIn - attribute`() {
         val policy = Exp.subject("blah") isIn resourceVal("foo")
-        assertThat(policy.operatorType).isEqualTo(OperatorType.IS_IN)
+        assertEquals(OperatorType.IS_IN, policy.operatorType)
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/expression/ExpressionPolicyTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/expression/ExpressionPolicyTest.kt
@@ -1,36 +1,39 @@
 package codes.laurence.warden.policy.expression
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
-import assertk.fail
 import codes.laurence.warden.AccessRequest
 import codes.laurence.warden.policy.Policy
 import codes.laurence.warden.test.assertDenied
 import codes.laurence.warden.test.assertGranted
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 class ComparisonOperatorsTest {
-    val request17 = AccessRequest().copy(
-        subject = mapOf(Pair("age", 17)),
-        resource = mapOf(Pair("limit", 18))
-    )
-    val request18 = AccessRequest().copy(
-        subject = mapOf(Pair("age", 18)),
-        resource = mapOf(Pair("limit", 18))
-    )
-    val request19 = AccessRequest().copy(
-        subject = mapOf(Pair("age", 19)),
-        resource = mapOf(Pair("limit", 18))
-    )
+    val request17 =
+        AccessRequest().copy(
+            subject = mapOf(Pair("age", 17)),
+            resource = mapOf(Pair("limit", 18)),
+        )
+    val request18 =
+        AccessRequest().copy(
+            subject = mapOf(Pair("age", 18)),
+            resource = mapOf(Pair("limit", 18)),
+        )
+    val request19 =
+        AccessRequest().copy(
+            subject = mapOf(Pair("age", 19)),
+            resource = mapOf(Pair("limit", 18)),
+        )
 
     @Test
     fun greaterThan() {
-        val greaterThan18: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("age")),
-            OperatorType.GREATER_THAN,
-            PassThroughReference(18)
-        )
+        val greaterThan18: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("age")),
+                OperatorType.GREATER_THAN,
+                PassThroughReference(18),
+            )
         assertDenied(greaterThan18.checkAuthorized(request17), request17)
         assertDenied(greaterThan18.checkAuthorized(request18), request18)
         assertGranted(greaterThan18.checkAuthorized(request19), request19)
@@ -38,11 +41,12 @@ class ComparisonOperatorsTest {
 
     @Test
     fun greaterThanEqual() {
-        val greaterThanEqual18: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("age")),
-            OperatorType.GREATER_THAN_EQUAL,
-            PassThroughReference(18)
-        )
+        val greaterThanEqual18: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("age")),
+                OperatorType.GREATER_THAN_EQUAL,
+                PassThroughReference(18),
+            )
         assertDenied(greaterThanEqual18.checkAuthorized(request17))
         assertGranted(greaterThanEqual18.checkAuthorized(request18))
         assertGranted(greaterThanEqual18.checkAuthorized(request19))
@@ -50,11 +54,12 @@ class ComparisonOperatorsTest {
 
     @Test
     fun equal() {
-        val equal18: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("age")),
-            OperatorType.EQUAL,
-            PassThroughReference(18)
-        )
+        val equal18: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("age")),
+                OperatorType.EQUAL,
+                PassThroughReference(18),
+            )
         assertDenied(equal18.checkAuthorized(request17))
         assertGranted(equal18.checkAuthorized(request18))
         assertDenied(equal18.checkAuthorized(request19))
@@ -62,28 +67,32 @@ class ComparisonOperatorsTest {
 
     @Test
     fun `equal to null`() {
-        val equalToNull: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.ENVIRONMENT, listOf("canBeNull")),
-            OperatorType.EQUAL,
-            PassThroughReference(null)
-        )
-        val isNullRequest = AccessRequest().copy(
-            environment = mapOf(Pair("canBeNull", null))
-        )
-        val isNotNullRequest = AccessRequest().copy(
-            environment = mapOf(Pair("canBeNull", "I am not"))
-        )
+        val equalToNull: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.ENVIRONMENT, listOf("canBeNull")),
+                OperatorType.EQUAL,
+                PassThroughReference(null),
+            )
+        val isNullRequest =
+            AccessRequest().copy(
+                environment = mapOf(Pair("canBeNull", null)),
+            )
+        val isNotNullRequest =
+            AccessRequest().copy(
+                environment = mapOf(Pair("canBeNull", "I am not")),
+            )
         assertDenied(equalToNull.checkAuthorized(isNotNullRequest))
         assertGranted(equalToNull.checkAuthorized(isNullRequest))
     }
 
     @Test
     fun lessThan() {
-        val lessThan18: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("age")),
-            OperatorType.LESS_THAN,
-            PassThroughReference(18)
-        )
+        val lessThan18: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("age")),
+                OperatorType.LESS_THAN,
+                PassThroughReference(18),
+            )
         assertGranted(lessThan18.checkAuthorized(request17))
         assertDenied(lessThan18.checkAuthorized(request18))
         assertDenied(lessThan18.checkAuthorized(request19))
@@ -91,11 +100,12 @@ class ComparisonOperatorsTest {
 
     @Test
     fun lessThanEqual() {
-        val lessThanEqual18: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("age")),
-            OperatorType.LESS_THAN_EQUAL,
-            PassThroughReference(18)
-        )
+        val lessThanEqual18: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("age")),
+                OperatorType.LESS_THAN_EQUAL,
+                PassThroughReference(18),
+            )
         assertGranted(lessThanEqual18.checkAuthorized(request17))
         assertGranted(lessThanEqual18.checkAuthorized(request18))
         assertDenied(lessThanEqual18.checkAuthorized(request19))
@@ -105,90 +115,103 @@ class ComparisonOperatorsTest {
     fun compareNonExistentKey() {
         val requestWithMissingKeys = AccessRequest()
 
-        val somePolicy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("not_here")),
-            OperatorType.LESS_THAN_EQUAL,
-            AttributeReference(AttributeType.RESOURCE, listOf("not_here"))
-        )
+        val somePolicy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("not_here")),
+                OperatorType.LESS_THAN_EQUAL,
+                AttributeReference(AttributeType.RESOURCE, listOf("not_here")),
+            )
         assertDenied(somePolicy.checkAuthorized(requestWithMissingKeys))
     }
 
     @Test
     fun compareSubjectToResource() {
-        val request17 = AccessRequest().copy(
-            subject = mapOf(Pair("age", 17)),
-            resource = mapOf(Pair("limit", 18))
-        )
-        val request18 = AccessRequest().copy(
-            subject = mapOf(Pair("age", 18)),
-            resource = mapOf(Pair("limit", 18))
-        )
+        val request17 =
+            AccessRequest().copy(
+                subject = mapOf(Pair("age", 17)),
+                resource = mapOf(Pair("limit", 18)),
+            )
+        val request18 =
+            AccessRequest().copy(
+                subject = mapOf(Pair("age", 18)),
+                resource = mapOf(Pair("limit", 18)),
+            )
 
-        val mustBeOverResourceLimitPolicy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("age")),
-            OperatorType.GREATER_THAN_EQUAL,
-            AttributeReference(AttributeType.RESOURCE, listOf("limit"))
-        )
+        val mustBeOverResourceLimitPolicy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("age")),
+                OperatorType.GREATER_THAN_EQUAL,
+                AttributeReference(AttributeType.RESOURCE, listOf("limit")),
+            )
         assertGranted(mustBeOverResourceLimitPolicy.checkAuthorized(request18))
         assertDenied(mustBeOverResourceLimitPolicy.checkAuthorized(request17))
     }
 
     @Test
     fun compareResourceToEnvironment() {
-        val expired = AccessRequest().copy(
-            resource = mapOf(Pair("expires", 1)),
-            environment = mapOf(Pair("timeOfRequest", 3))
-        )
-        val notExpired = AccessRequest().copy(
-            resource = mapOf(Pair("expires", 3)),
-            environment = mapOf(Pair("timeOfRequest", 1))
-        )
+        val expired =
+            AccessRequest().copy(
+                resource = mapOf(Pair("expires", 1)),
+                environment = mapOf(Pair("timeOfRequest", 3)),
+            )
+        val notExpired =
+            AccessRequest().copy(
+                resource = mapOf(Pair("expires", 3)),
+                environment = mapOf(Pair("timeOfRequest", 1)),
+            )
 
-        val policy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.RESOURCE, listOf("expires")),
-            OperatorType.GREATER_THAN_EQUAL,
-            AttributeReference(AttributeType.ENVIRONMENT, listOf("timeOfRequest"))
-        )
+        val policy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.RESOURCE, listOf("expires")),
+                OperatorType.GREATER_THAN_EQUAL,
+                AttributeReference(AttributeType.ENVIRONMENT, listOf("timeOfRequest")),
+            )
         assertDenied(policy.checkAuthorized(expired))
         assertGranted(policy.checkAuthorized(notExpired))
     }
 
     @Test
     fun compareEnvironmentToSubject() {
-        val notOnSite = AccessRequest().copy(
-            subject = mapOf(Pair("siteID", 3)),
-            environment = mapOf(Pair("requestSiteID", 4))
-        )
-        val onSite = AccessRequest().copy(
-            subject = mapOf(Pair("siteID", 3)),
-            environment = mapOf(Pair("requestSiteID", 3))
-        )
+        val notOnSite =
+            AccessRequest().copy(
+                subject = mapOf(Pair("siteID", 3)),
+                environment = mapOf(Pair("requestSiteID", 4)),
+            )
+        val onSite =
+            AccessRequest().copy(
+                subject = mapOf(Pair("siteID", 3)),
+                environment = mapOf(Pair("requestSiteID", 3)),
+            )
 
-        val subjectMustBeOnTheirSitePolicy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.ENVIRONMENT, listOf("requestSiteID")),
-            OperatorType.EQUAL,
-            AttributeReference(AttributeType.SUBJECT, listOf("siteID"))
-        )
+        val subjectMustBeOnTheirSitePolicy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.ENVIRONMENT, listOf("requestSiteID")),
+                OperatorType.EQUAL,
+                AttributeReference(AttributeType.SUBJECT, listOf("siteID")),
+            )
         assertDenied(subjectMustBeOnTheirSitePolicy.checkAuthorized(notOnSite))
         assertGranted(subjectMustBeOnTheirSitePolicy.checkAuthorized(onSite))
     }
 
     @Test
     fun compareActionToSubject() {
-        val hasReadPermission = AccessRequest().copy(
-            subject = mapOf(Pair("permission", "READ")),
-            action = mapOf(Pair("type", "READ"))
-        )
-        val noReadPermission = AccessRequest().copy(
-            subject = mapOf(Pair("permission", "NONE")),
-            action = mapOf(Pair("type", "READ"))
-        )
+        val hasReadPermission =
+            AccessRequest().copy(
+                subject = mapOf(Pair("permission", "READ")),
+                action = mapOf(Pair("type", "READ")),
+            )
+        val noReadPermission =
+            AccessRequest().copy(
+                subject = mapOf(Pair("permission", "NONE")),
+                action = mapOf(Pair("type", "READ")),
+            )
 
-        val userMustHaveActionPermission: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.ACTION, listOf("type")),
-            OperatorType.EQUAL,
-            AttributeReference(AttributeType.SUBJECT, listOf("permission"))
-        )
+        val userMustHaveActionPermission: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.ACTION, listOf("type")),
+                OperatorType.EQUAL,
+                AttributeReference(AttributeType.SUBJECT, listOf("permission")),
+            )
         assertDenied(userMustHaveActionPermission.checkAuthorized(noReadPermission))
         assertGranted(userMustHaveActionPermission.checkAuthorized(hasReadPermission))
     }
@@ -197,21 +220,25 @@ class ComparisonOperatorsTest {
 class CollectionOperatorsTest {
     @Test
     fun checkAttributeContainsAllOf() {
-        val allRoles = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER", "SUPERVISOR")))
-        )
-        val someRoles = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER")))
-        )
-        val noRoles = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER")))
-        )
+        val allRoles =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER", "SUPERVISOR"))),
+            )
+        val someRoles =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER"))),
+            )
+        val noRoles =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER"))),
+            )
 
-        val policy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("roles")),
-            OperatorType.CONTAINS_ALL,
-            PassThroughReference(listOf("ACCOUNT_MANAGER", "SUPERVISOR"))
-        )
+        val policy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("roles")),
+                OperatorType.CONTAINS_ALL,
+                PassThroughReference(listOf("ACCOUNT_MANAGER", "SUPERVISOR")),
+            )
         assertGranted(policy.checkAuthorized(allRoles))
         assertDenied(policy.checkAuthorized(someRoles))
         assertDenied(policy.checkAuthorized(noRoles))
@@ -219,21 +246,25 @@ class CollectionOperatorsTest {
 
     @Test
     fun checkAttributeContainsAnyOf() {
-        val managerRequest = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER")))
-        )
-        val supervisorRequest = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("ADMIN", "SUPERVISOR")))
-        )
-        val neitherRequest = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER", "ADMIN")))
-        )
+        val managerRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER"))),
+            )
+        val supervisorRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("ADMIN", "SUPERVISOR"))),
+            )
+        val neitherRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER", "ADMIN"))),
+            )
 
-        val policy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("roles")),
-            OperatorType.CONTAINS_ANY,
-            PassThroughReference(listOf("ACCOUNT_MANAGER", "SUPERVISOR"))
-        )
+        val policy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("roles")),
+                OperatorType.CONTAINS_ANY,
+                PassThroughReference(listOf("ACCOUNT_MANAGER", "SUPERVISOR")),
+            )
         assertGranted(policy.checkAuthorized(managerRequest))
         assertGranted(policy.checkAuthorized(supervisorRequest))
         assertDenied(policy.checkAuthorized(neitherRequest))
@@ -241,18 +272,21 @@ class CollectionOperatorsTest {
 
     @Test
     fun checkAttributeContains() {
-        val managerRequest = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER")))
-        )
-        val supervisorRequest = AccessRequest().copy(
-            subject = mapOf(Pair("roles", listOf("USER", "SUPERVISOR")))
-        )
+        val managerRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER", "ACCOUNT_MANAGER"))),
+            )
+        val supervisorRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("roles", listOf("USER", "SUPERVISOR"))),
+            )
 
-        val policy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("roles")),
-            OperatorType.CONTAINS,
-            PassThroughReference("ACCOUNT_MANAGER")
-        )
+        val policy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("roles")),
+                OperatorType.CONTAINS,
+                PassThroughReference("ACCOUNT_MANAGER"),
+            )
 
         assertGranted(policy.checkAuthorized(managerRequest))
         assertDenied(policy.checkAuthorized(supervisorRequest))
@@ -260,21 +294,25 @@ class CollectionOperatorsTest {
 
     @Test
     fun checkAttributeIsIn() {
-        val managerRequest = AccessRequest().copy(
-            subject = mapOf(Pair("role", "ACCOUNT_MANAGER"))
-        )
-        val supervisorRequest = AccessRequest().copy(
-            subject = mapOf(Pair("role", "SUPERVISOR"))
-        )
-        val engineerRequest = AccessRequest().copy(
-            subject = mapOf(Pair("role", "ENGINEER"))
-        )
+        val managerRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("role", "ACCOUNT_MANAGER")),
+            )
+        val supervisorRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("role", "SUPERVISOR")),
+            )
+        val engineerRequest =
+            AccessRequest().copy(
+                subject = mapOf(Pair("role", "ENGINEER")),
+            )
 
-        val policy: Policy = ExpressionPolicy(
-            AttributeReference(AttributeType.SUBJECT, listOf("role")),
-            OperatorType.IS_IN,
-            PassThroughReference(listOf("ACCOUNT_MANAGER", "SUPERVISOR"))
-        )
+        val policy: Policy =
+            ExpressionPolicy(
+                AttributeReference(AttributeType.SUBJECT, listOf("role")),
+                OperatorType.IS_IN,
+                PassThroughReference(listOf("ACCOUNT_MANAGER", "SUPERVISOR")),
+            )
         assertGranted(policy.checkAuthorized(managerRequest))
         assertGranted(policy.checkAuthorized(supervisorRequest))
         assertDenied(policy.checkAuthorized(engineerRequest))
@@ -282,16 +320,15 @@ class CollectionOperatorsTest {
 }
 
 class AttributeReferenceTest {
-
     @Test
     fun `cannot instantiate with empty list`() {
         try {
             AttributeReference(
                 type = AttributeType.values().random(),
-                path = emptyList()
+                path = emptyList(),
             )
         } catch (e: Exception) {
-            assertThat(e).isInstanceOf(IllegalArgumentException::class)
+            assertIs<IllegalArgumentException>(e)
         }
     }
 
@@ -300,31 +337,38 @@ class AttributeReferenceTest {
         val path = listOf("foo")
         val value = "bar"
 
-        val attributes = mapOf(
-            "foo" to "bar"
-        )
+        val attributes =
+            mapOf(
+                "foo" to "bar",
+            )
 
-        val testObj = AttributeReference(
-            type = AttributeType.values().random(),
-            path = path
-        )
+        val testObj =
+            AttributeReference(
+                type = AttributeType.values().random(),
+                path = path,
+            )
 
-        val accessRequest = when (testObj.type) {
-            AttributeType.SUBJECT -> AccessRequest(
-                subject = attributes
-            )
-            AttributeType.ACTION -> AccessRequest(
-                action = attributes
-            )
-            AttributeType.RESOURCE -> AccessRequest(
-                resource = attributes
-            )
-            AttributeType.ENVIRONMENT -> AccessRequest(
-                environment = attributes
-            )
-        }
+        val accessRequest =
+            when (testObj.type) {
+                AttributeType.SUBJECT ->
+                    AccessRequest(
+                        subject = attributes,
+                    )
+                AttributeType.ACTION ->
+                    AccessRequest(
+                        action = attributes,
+                    )
+                AttributeType.RESOURCE ->
+                    AccessRequest(
+                        resource = attributes,
+                    )
+                AttributeType.ENVIRONMENT ->
+                    AccessRequest(
+                        environment = attributes,
+                    )
+            }
 
-        assertThat(testObj.get(accessRequest)).isEqualTo(value)
+        assertEquals(value, testObj.get(accessRequest))
     }
 
     @Test
@@ -332,68 +376,79 @@ class AttributeReferenceTest {
         val path = listOf("wack", "foo")
         val value = "bar"
 
-        val attributes = mapOf(
-            "wack" to mapOf(
-                "foo" to value
+        val attributes =
+            mapOf(
+                "wack" to
+                    mapOf(
+                        "foo" to value,
+                    ),
             )
-        )
 
-        val testObj = AttributeReference(
-            type = AttributeType.values().random(),
-            path = path
-        )
+        val testObj =
+            AttributeReference(
+                type = AttributeType.values().random(),
+                path = path,
+            )
 
-        val accessRequest = when (testObj.type) {
-            AttributeType.SUBJECT -> AccessRequest(
-                subject = attributes
-            )
-            AttributeType.ACTION -> AccessRequest(
-                action = attributes
-            )
-            AttributeType.RESOURCE -> AccessRequest(
-                resource = attributes
-            )
-            AttributeType.ENVIRONMENT -> AccessRequest(
-                environment = attributes
-            )
-        }
+        val accessRequest =
+            when (testObj.type) {
+                AttributeType.SUBJECT ->
+                    AccessRequest(
+                        subject = attributes,
+                    )
+                AttributeType.ACTION ->
+                    AccessRequest(
+                        action = attributes,
+                    )
+                AttributeType.RESOURCE ->
+                    AccessRequest(
+                        resource = attributes,
+                    )
+                AttributeType.ENVIRONMENT ->
+                    AccessRequest(
+                        environment = attributes,
+                    )
+            }
 
-        assertThat(testObj.get(accessRequest)).isEqualTo(value)
+        assertEquals(value, testObj.get(accessRequest))
     }
 
     @Test
     fun `get - nested path - nested value is not a map`() {
         val path = listOf("wack", "foo")
 
-        val attributes = mapOf(
-            "wack" to "foo"
-        )
+        val attributes =
+            mapOf(
+                "wack" to "foo",
+            )
 
-        val testObj = AttributeReference(
-            type = AttributeType.values().random(),
-            path = path
-        )
+        val testObj =
+            AttributeReference(
+                type = AttributeType.values().random(),
+                path = path,
+            )
 
-        val accessRequest = when (testObj.type) {
-            AttributeType.SUBJECT -> AccessRequest(
-                subject = attributes
-            )
-            AttributeType.ACTION -> AccessRequest(
-                action = attributes
-            )
-            AttributeType.RESOURCE -> AccessRequest(
-                resource = attributes
-            )
-            AttributeType.ENVIRONMENT -> AccessRequest(
-                environment = attributes
-            )
-        }
-
-        try {
+        val accessRequest =
+            when (testObj.type) {
+                AttributeType.SUBJECT ->
+                    AccessRequest(
+                        subject = attributes,
+                    )
+                AttributeType.ACTION ->
+                    AccessRequest(
+                        action = attributes,
+                    )
+                AttributeType.RESOURCE ->
+                    AccessRequest(
+                        resource = attributes,
+                    )
+                AttributeType.ENVIRONMENT ->
+                    AccessRequest(
+                        environment = attributes,
+                    )
+            }
+        assertFailsWith<NoSuchAttributeException> {
             testObj.get(accessRequest)
-            fail("Should be exception")
-        } catch (e: Exception) {
-            assertThat(e).isInstanceOf(NoSuchAttributeException::class)
         }
     }
 
@@ -402,37 +457,42 @@ class AttributeReferenceTest {
         val path = listOf("wack", "foo")
         val value = "bar"
 
-        val attributes = mapOf(
-            "wack" to mapOf(
-                "notFoo" to value
+        val attributes =
+            mapOf(
+                "wack" to
+                    mapOf(
+                        "notFoo" to value,
+                    ),
             )
-        )
 
-        val testObj = AttributeReference(
-            type = AttributeType.values().random(),
-            path = path
-        )
+        val testObj =
+            AttributeReference(
+                type = AttributeType.values().random(),
+                path = path,
+            )
 
-        val accessRequest = when (testObj.type) {
-            AttributeType.SUBJECT -> AccessRequest(
-                subject = attributes
-            )
-            AttributeType.ACTION -> AccessRequest(
-                action = attributes
-            )
-            AttributeType.RESOURCE -> AccessRequest(
-                resource = attributes
-            )
-            AttributeType.ENVIRONMENT -> AccessRequest(
-                environment = attributes
-            )
-        }
+        val accessRequest =
+            when (testObj.type) {
+                AttributeType.SUBJECT ->
+                    AccessRequest(
+                        subject = attributes,
+                    )
+                AttributeType.ACTION ->
+                    AccessRequest(
+                        action = attributes,
+                    )
+                AttributeType.RESOURCE ->
+                    AccessRequest(
+                        resource = attributes,
+                    )
+                AttributeType.ENVIRONMENT ->
+                    AccessRequest(
+                        environment = attributes,
+                    )
+            }
 
-        try {
+        assertFailsWith<NoSuchAttributeException> {
             testObj.get(accessRequest)
-            fail("Should be exception")
-        } catch (e: Exception) {
-            assertThat(e).isInstanceOf(NoSuchAttributeException::class)
         }
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/members/MembersDSLTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/members/MembersDSLTest.kt
@@ -1,92 +1,90 @@
 package codes.laurence.warden.policy.members
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.fail
 import codes.laurence.warden.policy.bool.allOf
 import codes.laurence.warden.policy.expression.AttributeReference
 import codes.laurence.warden.policy.expression.AttributeType
 import codes.laurence.warden.policy.expression.OperatorType
 import codes.laurence.warden.policy.expression.subjectVal
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 class MembersDSLTest {
-
     @Test
     fun forAnyMember() {
-        val parentPolicy = allOf {
-            subject("foo") forAnyMember {
-                attribute("bar", "doe") equalTo subjectVal("wack")
-                attribute("rae") contains subjectVal("wack")
+        val parentPolicy =
+            allOf {
+                subject("foo") forAnyMember {
+                    attribute("bar", "doe") equalTo subjectVal("wack")
+                    attribute("rae") contains subjectVal("wack")
+                }
             }
-        }
 
-        val expected = ForAnyMemberPolicy(
-            memberSource = AttributeReference(AttributeType.SUBJECT, listOf("foo")),
-            memberPolicies = listOf(
-                MemberExpressionPolicy(
-                    leftOperand = MemberAttributeReference(listOf("bar", "doe")),
-                    operatorType = OperatorType.EQUAL,
-                    rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack"))
+        val expected =
+            ForAnyMemberPolicy(
+                memberSource = AttributeReference(AttributeType.SUBJECT, listOf("foo")),
+                memberPolicies =
+                listOf(
+                    MemberExpressionPolicy(
+                        leftOperand = MemberAttributeReference(listOf("bar", "doe")),
+                        operatorType = OperatorType.EQUAL,
+                        rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack")),
+                    ),
+                    MemberExpressionPolicy(
+                        leftOperand = MemberAttributeReference(listOf("rae")),
+                        operatorType = OperatorType.CONTAINS,
+                        rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack")),
+                    ),
                 ),
-                MemberExpressionPolicy(
-                    leftOperand = MemberAttributeReference(listOf("rae")),
-                    operatorType = OperatorType.CONTAINS,
-                    rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack"))
-                )
-            ),
-        )
+            )
 
         val actual = parentPolicy.policies.first() as ForAnyMemberPolicy
-        assertThat(actual.memberSource).isEqualTo(expected.memberSource)
+        assertEquals(expected.memberSource, actual.memberSource)
 
         actual.memberPolicies.forEachIndexed { index, actualPolicy ->
             val expectedPolicy = expected.memberPolicies[index] as MemberExpressionPolicy
-            if (actualPolicy is MemberExpressionPolicy) {
-                assertThat(actualPolicy.leftOperand).isEqualTo(expectedPolicy.leftOperand)
-                assertThat(actualPolicy.internalExpressionPolicy).isEqualTo(expectedPolicy.internalExpressionPolicy)
-            } else {
-                fail("Not expected type")
-            }
+            assertIs<MemberExpressionPolicy>(actualPolicy)
+            assertEquals(expectedPolicy.leftOperand, actualPolicy.leftOperand)
+            assertEquals(expectedPolicy.internalExpressionPolicy, actualPolicy.internalExpressionPolicy)
         }
     }
 
     @Test
     fun forAllMembers() {
-        val parentPolicy = allOf {
-            subject("foo") forAllMembers {
-                attribute("bar", "doe") equalTo subjectVal("wack")
-                attribute("rae") contains subjectVal("wack")
+        val parentPolicy =
+            allOf {
+                subject("foo") forAllMembers {
+                    attribute("bar", "doe") equalTo subjectVal("wack")
+                    attribute("rae") contains subjectVal("wack")
+                }
             }
-        }
 
-        val expected = ForAllMembersPolicy(
-            memberSource = AttributeReference(AttributeType.SUBJECT, listOf("foo")),
-            memberPolicies = listOf(
-                MemberExpressionPolicy(
-                    leftOperand = MemberAttributeReference(listOf("bar", "doe")),
-                    operatorType = OperatorType.EQUAL,
-                    rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack"))
+        val expected =
+            ForAllMembersPolicy(
+                memberSource = AttributeReference(AttributeType.SUBJECT, listOf("foo")),
+                memberPolicies =
+                listOf(
+                    MemberExpressionPolicy(
+                        leftOperand = MemberAttributeReference(listOf("bar", "doe")),
+                        operatorType = OperatorType.EQUAL,
+                        rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack")),
+                    ),
+                    MemberExpressionPolicy(
+                        leftOperand = MemberAttributeReference(listOf("rae")),
+                        operatorType = OperatorType.CONTAINS,
+                        rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack")),
+                    ),
                 ),
-                MemberExpressionPolicy(
-                    leftOperand = MemberAttributeReference(listOf("rae")),
-                    operatorType = OperatorType.CONTAINS,
-                    rightOperand = AttributeReference(AttributeType.SUBJECT, path = listOf("wack"))
-                )
-            ),
-        )
+            )
 
         val actual = parentPolicy.policies.first() as ForAllMembersPolicy
-        assertThat(actual.memberSource).isEqualTo(expected.memberSource)
+        assertEquals(expected.memberSource, actual.memberSource)
 
         actual.memberPolicies.forEachIndexed { index, actualPolicy ->
             val expectedPolicy = expected.memberPolicies[index] as MemberExpressionPolicy
-            if (actualPolicy is MemberExpressionPolicy) {
-                assertThat(actualPolicy.leftOperand).isEqualTo(expectedPolicy.leftOperand)
-                assertThat(actualPolicy.internalExpressionPolicy).isEqualTo(expectedPolicy.internalExpressionPolicy)
-            } else {
-                fail("Not expected type")
-            }
+            assertIs<MemberExpressionPolicy>(actualPolicy)
+            assertEquals(expectedPolicy.leftOperand, actualPolicy.leftOperand)
+            assertEquals(expectedPolicy.internalExpressionPolicy, actualPolicy.internalExpressionPolicy)
         }
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/policy/members/MembersPolicyTest.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/policy/members/MembersPolicyTest.kt
@@ -1,87 +1,113 @@
 package codes.laurence.warden.policy.members
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
 import codes.laurence.warden.Access
 import codes.laurence.warden.AccessRequest
 import codes.laurence.warden.AccessResponse
-import codes.laurence.warden.policy.expression.*
-import io.mockk.coVerifyOrder
-import io.mockk.every
-import io.mockk.mockk
+import codes.laurence.warden.policy.expression.AttributeReference
+import codes.laurence.warden.policy.expression.AttributeType
+import codes.laurence.warden.policy.expression.NoSuchAttributeException
+import codes.laurence.warden.policy.expression.OperatorType
+import codes.laurence.warden.policy.expression.ValueReference
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.eq
+import io.mockative.every
+import io.mockative.mock
+import io.mockative.ne
+import kotlinx.coroutines.runBlocking
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.fail
 
 private val MEMBER_1 = mapOf("1" to 1)
 private val MEMBER_2 = mapOf("1" to 2)
 
-private val MEMBERS = listOf(
-    MEMBER_1,
-    MEMBER_2
-)
+private val MEMBERS =
+    listOf(
+        MEMBER_1,
+        MEMBER_2,
+    )
 
-private val DENY_ALL_MEMBER_POLICY = mockk<MemberPolicy> {
-    every { checkAuthorized(any(), any()) } answers {
-        AccessResponse(
-            access = Access.Denied(),
-            request = arg(1)
-        )
-    }
-}
+private val accessRequest = AccessRequest()
 
-private val GRANTED_ALL_MEMBER_POLICY = mockk<MemberPolicy> {
-    every { checkAuthorized(any(), any()) } answers {
-        AccessResponse(
-            access = Access.Granted(),
-            request = arg(1)
-        )
-    }
-}
+@Mock
+private val DENY_ALL_MEMBER_POLICY = mock(classOf<MemberPolicy>())
 
-private val GRANTED_MEMBER_1_POLICY = mockk<MemberPolicy> {
-    every { checkAuthorized(any(), any()) } answers {
-        if (arg<Map<*, *>>(0) == MEMBER_1) {
-            AccessResponse(
-                access = Access.Granted(),
-                request = arg(1)
-            )
-        } else {
+@Mock
+private val GRANTED_ALL_MEMBER_POLICY = mock(classOf<MemberPolicy>())
+
+@Mock
+private val GRANTED_MEMBER_1_POLICY = mock(classOf<MemberPolicy>())
+
+@Mock
+private val GRANTED_MEMBER_2_POLICY = mock(classOf<MemberPolicy>())
+
+@Mock
+val memberSource = mock(classOf<ValueReference>())
+
+@Mock
+val memberPolicy = mock(classOf<MemberPolicy>())
+
+fun mockClasses() =
+    runBlocking {
+        every { DENY_ALL_MEMBER_POLICY.checkAuthorized(any(), any()) }.returns(
             AccessResponse(
                 access = Access.Denied(),
-                request = arg(1)
-            )
-        }
-    }
-}
+                request = accessRequest,
+            ),
+        )
 
-private val GRANTED_MEMBER_2_POLICY = mockk<MemberPolicy> {
-    every { checkAuthorized(any(), any()) } answers {
-        if (arg<Map<*, *>>(0) == MEMBER_2) {
+        every { GRANTED_ALL_MEMBER_POLICY.checkAuthorized(any(), any()) }.returns(
             AccessResponse(
                 access = Access.Granted(),
-                request = arg(1)
-            )
-        } else {
+                request = accessRequest,
+            ),
+        )
+
+        every { GRANTED_MEMBER_1_POLICY.checkAuthorized(eq(MEMBER_1), any()) }.returns(
+            AccessResponse(
+                access = Access.Granted(),
+                request = accessRequest,
+            ),
+        )
+
+        every { GRANTED_MEMBER_1_POLICY.checkAuthorized(ne(MEMBER_1), any()) }.returns(
+
             AccessResponse(
                 access = Access.Denied(),
-                request = arg(1)
-            )
-        }
+                request = accessRequest,
+            ),
+        )
+
+        every { GRANTED_MEMBER_2_POLICY.checkAuthorized(eq(MEMBER_2), any()) }.returns(
+            AccessResponse(
+                access = Access.Granted(),
+                request = accessRequest,
+            ),
+        )
+        every { GRANTED_MEMBER_2_POLICY.checkAuthorized(ne(MEMBER_2), any()) }.returns(
+            AccessResponse(
+                access = Access.Denied(),
+                request = accessRequest,
+            ),
+        )
     }
-}
 
 class ForAnyMemberPolicyTest {
+    @BeforeTest
+    fun beforeEachTest() = mockClasses()
 
     @Test
     fun `initialise - empty member policies`() {
         val memberPolicies: List<MemberPolicy> = emptyList()
-        val memberSource: ValueReference = mockk()
 
         try {
             ForAnyMemberPolicy(
                 memberSource = memberSource,
-                memberPolicies = memberPolicies
+                memberPolicies = memberPolicies,
             )
             fail("Should be invalid state")
         } catch (e: IllegalArgumentException) {
@@ -91,13 +117,12 @@ class ForAnyMemberPolicyTest {
 
     @Test
     fun `initialise - member policies`() {
-        val memberPolicies: List<MemberPolicy> = listOf(mockk())
-        val memberSource: ValueReference = mockk()
+        val memberPolicies: List<MemberPolicy> = listOf(memberPolicy)
 
         try {
             ForAnyMemberPolicy(
                 memberSource = memberSource,
-                memberPolicies = memberPolicies
+                memberPolicies = memberPolicies,
             )
         } catch (e: IllegalArgumentException) {
             fail("Should be fine")
@@ -106,172 +131,177 @@ class ForAnyMemberPolicyTest {
 
     @Test
     fun `check - member source not a collection`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns "MEMBERS"
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
 
-        val testObj = ForAnyMemberPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        every { memberSource.get(accessRequest) }.returns("MEMBERS")
+
+        val testObj =
+            ForAnyMemberPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - member source present`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } throws NoSuchAttributeException()
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
 
-        val testObj = ForAnyMemberPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        every { memberSource.get(accessRequest) }.throws(NoSuchAttributeException())
+
+        val testObj =
+            ForAnyMemberPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - members not maps`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns listOf("member")
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
 
-        val testObj = ForAnyMemberPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        every { memberSource.get(accessRequest) }.returns(listOf("member"))
+
+        val testObj =
+            ForAnyMemberPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - some members granted by all policies - expect granted`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_MEMBER_2_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns MEMBERS
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_MEMBER_2_POLICY,
+            )
 
-        val testObj = ForAnyMemberPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        every { memberSource.get(accessRequest) }.returns(MEMBERS)
+
+        val testObj =
+            ForAnyMemberPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Granted(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - members granted by some policies but no member for all policies - expect denied`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_MEMBER_1_POLICY,
-            GRANTED_MEMBER_2_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns MEMBERS
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_MEMBER_1_POLICY,
+                GRANTED_MEMBER_2_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns(MEMBERS)
 
-        val testObj = ForAnyMemberPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAnyMemberPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - all deny - expect deny`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            DENY_ALL_MEMBER_POLICY,
-            DENY_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns MEMBERS
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                DENY_ALL_MEMBER_POLICY,
+                DENY_ALL_MEMBER_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns(MEMBERS)
 
-        val testObj = ForAnyMemberPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAnyMemberPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 }
 
 class ForAllMembersPolicyTest {
+    @BeforeTest
+    fun beforeEachTest() = mockClasses()
 
     @Test
     fun `initialise - empty member policies`() {
         val memberPolicies: List<MemberPolicy> = emptyList()
-        val memberSource: ValueReference = mockk()
 
         try {
             ForAllMembersPolicy(
                 memberSource = memberSource,
-                memberPolicies = memberPolicies
+                memberPolicies = memberPolicies,
             )
             fail("Should be invalid state")
         } catch (e: IllegalArgumentException) {
@@ -281,13 +311,12 @@ class ForAllMembersPolicyTest {
 
     @Test
     fun `initialise - member policies`() {
-        val memberPolicies: List<MemberPolicy> = listOf(mockk())
-        val memberSource: ValueReference = mockk()
+        val memberPolicies: List<MemberPolicy> = listOf(memberPolicy)
 
         try {
             ForAllMembersPolicy(
                 memberSource = memberSource,
-                memberPolicies = memberPolicies
+                memberPolicies = memberPolicies,
             )
         } catch (e: IllegalArgumentException) {
             fail("Should be fine")
@@ -296,171 +325,173 @@ class ForAllMembersPolicyTest {
 
     @Test
     fun `check - member source not a collection`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns "MEMBERS"
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns("MEMBERS")
 
-        val testObj = ForAllMembersPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAllMembersPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - member source not present`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } throws NoSuchAttributeException()
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.throws(NoSuchAttributeException())
 
-        val testObj = ForAllMembersPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAllMembersPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - members not maps`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns listOf("member")
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns(listOf("member"))
 
-        val testObj = ForAllMembersPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAllMembersPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - some members granted by all policies - expect denied`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_MEMBER_2_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns MEMBERS
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_MEMBER_2_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns(MEMBERS)
 
-        val testObj = ForAllMembersPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAllMembersPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - all deny - expect deny`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            DENY_ALL_MEMBER_POLICY,
-            DENY_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns MEMBERS
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                DENY_ALL_MEMBER_POLICY,
+                DENY_ALL_MEMBER_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns(MEMBERS)
 
-        val testObj = ForAllMembersPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAllMembersPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Denied(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 
     @Test
     fun `check - all members granted by all policies - expect granted`() {
-        val memberPolicies: List<MemberPolicy> = listOf(
-            GRANTED_ALL_MEMBER_POLICY,
-            GRANTED_ALL_MEMBER_POLICY,
-        )
-        val accessRequest: AccessRequest = mockk()
-        val memberSource: ValueReference = mockk {
-            every { get(accessRequest) } returns MEMBERS
-        }
+        val memberPolicies: List<MemberPolicy> =
+            listOf(
+                GRANTED_ALL_MEMBER_POLICY,
+                GRANTED_ALL_MEMBER_POLICY,
+            )
+        every { memberSource.get(accessRequest) }.returns(MEMBERS)
 
-        val testObj = ForAllMembersPolicy(
-            memberSource = memberSource,
-            memberPolicies = memberPolicies
-        )
+        val testObj =
+            ForAllMembersPolicy(
+                memberSource = memberSource,
+                memberPolicies = memberPolicies,
+            )
 
         val actual = testObj.checkAuthorized(accessRequest)
 
-        assertThat(actual).isEqualTo(
+        assertEquals(
             AccessResponse(
                 access = Access.Granted(),
-                request = accessRequest
-            )
+                request = accessRequest,
+            ),
+            actual,
         )
     }
 }
 
 class MemberAttributeReferenceTest {
+    @BeforeTest
+    fun beforeEachTest() = mockClasses()
 
     @Test
     fun `cannot instantiate with empty list`() {
         try {
             MemberAttributeReference(
-                path = emptyList()
+                path = emptyList(),
             )
         } catch (e: Exception) {
-            assertThat(e).isInstanceOf(IllegalArgumentException::class)
+            assertIs<IllegalArgumentException>(e)
         }
     }
 
@@ -469,28 +500,31 @@ class MemberAttributeReferenceTest {
         val path = listOf("foo")
         val value = "bar"
 
-        val member = mapOf(
-            "foo" to "bar"
-        )
+        val member =
+            mapOf(
+                "foo" to "bar",
+            )
 
-        val testObj = MemberAttributeReference(
-            path = path
-        )
+        val testObj =
+            MemberAttributeReference(
+                path = path,
+            )
         testObj.member = member
 
-        assertThat(testObj.get(mockk())).isEqualTo(value)
+        assertEquals(value, testObj.get(accessRequest))
     }
 
     @Test
     fun `get - member not set`() {
         val path = listOf("foo")
 
-        val testObj = MemberAttributeReference(
-            path = path
-        )
+        val testObj =
+            MemberAttributeReference(
+                path = path,
+            )
 
         try {
-            testObj.get(mockk())
+            testObj.get(accessRequest)
             fail("Should be invalid")
         } catch (e: IllegalStateException) {
             // all good
@@ -502,38 +536,43 @@ class MemberAttributeReferenceTest {
         val path = listOf("wack", "foo")
         val value = "bar"
 
-        val member = mapOf(
-            "wack" to mapOf(
-                "foo" to value
+        val member =
+            mapOf(
+                "wack" to
+                    mapOf(
+                        "foo" to value,
+                    ),
             )
-        )
 
-        val testObj = MemberAttributeReference(
-            path = path
-        )
+        val testObj =
+            MemberAttributeReference(
+                path = path,
+            )
         testObj.member = member
 
-        assertThat(testObj.get(mockk())).isEqualTo(value)
+        assertEquals(value, testObj.get(accessRequest))
     }
 
     @Test
     fun `get - nested path - nested value is not a map`() {
         val path = listOf("wack", "foo")
 
-        val member = mapOf(
-            "wack" to "foo"
-        )
+        val member =
+            mapOf(
+                "wack" to "foo",
+            )
 
-        val testObj = MemberAttributeReference(
-            path = path
-        )
+        val testObj =
+            MemberAttributeReference(
+                path = path,
+            )
         testObj.member = member
 
         try {
-            testObj.get(mockk())
-            assertk.fail("Should be exception")
+            testObj.get(accessRequest)
+            fail("Should be exception")
         } catch (e: Exception) {
-            assertThat(e).isInstanceOf(NoSuchAttributeException::class)
+            assertIs<NoSuchAttributeException>(e)
         }
     }
 
@@ -542,27 +581,32 @@ class MemberAttributeReferenceTest {
         val path = listOf("wack", "foo")
         val value = "bar"
 
-        val member = mapOf(
-            "wack" to mapOf(
-                "notFoo" to value
+        val member =
+            mapOf(
+                "wack" to
+                    mapOf(
+                        "notFoo" to value,
+                    ),
             )
-        )
 
-        val testObj = MemberAttributeReference(
-            path = path
-        )
+        val testObj =
+            MemberAttributeReference(
+                path = path,
+            )
         testObj.member = member
 
         try {
-            testObj.get(mockk())
-            assertk.fail("Should be exception")
+            testObj.get(accessRequest)
+            fail("Should be exception")
         } catch (e: Exception) {
-            assertThat(e).isInstanceOf(NoSuchAttributeException::class)
+            assertIs<NoSuchAttributeException>(e)
         }
     }
 }
 
 class MemberExpressionPolicyTest {
+    @BeforeTest
+    fun beforeEachTest() = mockClasses()
 
     @Test
     fun initialization() {
@@ -570,45 +614,15 @@ class MemberExpressionPolicyTest {
         val operator = OperatorType.values().random()
         val rightOperand = AttributeReference(AttributeType.values().random(), listOf("bar"))
 
-        val testObj = MemberExpressionPolicy(
-            leftOperand = leftOperand,
-            operatorType = operator,
-            rightOperand = rightOperand
-        )
+        val testObj =
+            MemberExpressionPolicy(
+                leftOperand = leftOperand,
+                operatorType = operator,
+                rightOperand = rightOperand,
+            )
 
-        assertThat(testObj.internalExpressionPolicy.leftOperand).isEqualTo(leftOperand)
-        assertThat(testObj.internalExpressionPolicy.operatorType).isEqualTo(operator)
-        assertThat(testObj.internalExpressionPolicy.rightOperand).isEqualTo(rightOperand)
-    }
-
-    @Test
-    fun checkAuthorized() {
-        val leftOperand = mockk<MemberAttributeReference>(relaxed = true)
-        val operator = OperatorType.values().random()
-        val rightOperand = AttributeReference(AttributeType.values().random(), listOf("bar"))
-
-        val testObj = MemberExpressionPolicy(
-            leftOperand = leftOperand,
-            operatorType = operator,
-            rightOperand = rightOperand
-        )
-
-        val request = mockk<AccessRequest> {}
-        val result = AccessResponse(
-            access = listOf(Access.Denied(), Access.Granted()).random(),
-            request = request
-        )
-        val member = mapOf("1" to 1)
-        testObj.internalExpressionPolicy = mockk {
-            every { checkAuthorized(request) } returns result
-        }
-
-        val actual = testObj.checkAuthorized(member, request)
-
-        assertThat(actual).isEqualTo(result)
-        coVerifyOrder {
-            leftOperand.member = member
-            testObj.internalExpressionPolicy.checkAuthorized(request)
-        }
+        assertEquals(leftOperand, testObj.internalExpressionPolicy.leftOperand)
+        assertEquals(operator, testObj.internalExpressionPolicy.operatorType)
+        assertEquals(rightOperand, testObj.internalExpressionPolicy.rightOperand)
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/test/assertions.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/test/assertions.kt
@@ -1,22 +1,27 @@
 package codes.laurence.warden.test
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isInstanceOf
 import codes.laurence.warden.Access
 import codes.laurence.warden.AccessRequest
 import codes.laurence.warden.AccessResponse
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
-fun assertDenied(response: AccessResponse, expectedRequest: AccessRequest? = null) {
-    assertThat(response.access).isInstanceOf(Access.Denied::class)
+fun assertDenied(
+    response: AccessResponse,
+    expectedRequest: AccessRequest? = null,
+) {
+    assertIs<Access.Denied>(response.access)
     expectedRequest?.let {
-        assertThat(response.request).isEqualTo(expectedRequest)
+        assertEquals(expectedRequest, response.request)
     }
 }
 
-fun assertGranted(response: AccessResponse, expectedRequest: AccessRequest? = null) {
-    assertThat(response.access).isInstanceOf(Access.Granted::class)
+fun assertGranted(
+    response: AccessResponse,
+    expectedRequest: AccessRequest? = null,
+) {
+    assertIs<Access.Granted>(response.access)
     expectedRequest?.let {
-        assertThat(response.request).isEqualTo(expectedRequest)
+        assertEquals(expectedRequest, response.request)
     }
 }

--- a/core/src/commonTest/kotlin/codes/laurence/warden/test/fixtures.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/test/fixtures.kt
@@ -10,7 +10,7 @@ fun expressionPolicyFixture(): ExpressionPolicy {
     return ExpressionPolicy(
         leftOperand = valueReferenceFixture(),
         operatorType = randEnum(),
-        rightOperand = valueReferenceFixture()
+        rightOperand = valueReferenceFixture(),
     )
 }
 
@@ -18,9 +18,9 @@ fun valueReferenceFixture(): ValueReference {
     return listOf(
         AttributeReference(
             type = randEnum(),
-            path = listOf(randString())
+            path = listOf(randString()),
         ),
-        PassThroughReference(randString())
+        PassThroughReference(randString()),
     ).random()
 }
 

--- a/core/src/commonTest/kotlin/codes/laurence/warden/test/random.kt
+++ b/core/src/commonTest/kotlin/codes/laurence/warden/test/random.kt
@@ -17,15 +17,24 @@ fun <T> MutableList<T>.randomPop(): T {
     return removeAt(random.nextInt(this.size))
 }
 
-fun randRange(min: Double, max: Double): Double {
+fun randRange(
+    min: Double,
+    max: Double,
+): Double {
     return min + (max - min) * random.nextDouble()
 }
 
-fun randRange(min: Int, max: Int): Int {
+fun randRange(
+    min: Int,
+    max: Int,
+): Int {
     return random.nextInt(max - min) + min
 }
 
-fun randRange(min: Long, max: Long): Long {
+fun randRange(
+    min: Long,
+    max: Long,
+): Long {
     return (min + (max - min) * random.nextDouble()).toLong()
 }
 

--- a/core/src/nativeTest/kotlin/codes/laurence/warden/coroutines/patch.native.kt
+++ b/core/src/nativeTest/kotlin/codes/laurence/warden/coroutines/patch.native.kt
@@ -1,0 +1,4 @@
+package codes.laurence.warden.coroutines
+
+actual fun runBlockingTest(testBlock: suspend () -> Unit) {
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
 kotlin.code.style=official
 
-kotlinVersion=1.6.21
+kotlinVersion=1.9.10
 ktorVersion=2.0.2
 mockkVersion=1.9.3
+mockativeVersion=2.0.1
 orchidVersion=0.21.1
 assertKVersion=0.22
 slf4jVersion=1.7.30

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Some dependencies neeeded to be upgraded (kotlin, gradle, couroutines)
- The tests that were in the commonTest were actually jvm specific
- assertk was removed (kotlin.test was used for the asserts)
- mockk was replaced with mockative (multiplatform library for mocking)
- nativeMain (and ios dependencies)  was added
- atts and ktor remais jvm only